### PR TITLE
feat: show intermediate AI responses in timeline and stream content in trace

### DIFF
--- a/src/COMPONENTs/chat-bubble/chat_bubble.js
+++ b/src/COMPONENTs/chat-bubble/chat_bubble.js
@@ -83,56 +83,74 @@ const ChatBubble = ({
       }}
     >
       {isAssistant && traceFrames.length > 0 && (
-        <TraceChain frames={traceFrames} status={message.status} />
+        <TraceChain
+          frames={traceFrames}
+          status={message.status}
+          streamingContent={
+            message.status === "streaming" ? message.content : ""
+          }
+        />
       )}
-      {isAssistant && traceFrames.length === 0 && message.status === "streaming" && (
-        <TraceChain frames={[]} status={message.status} />
-      )}
-
-      <div
-        style={{
-          maxWidth: isUser ? "75%" : "100%",
-          width: isUser && isEditing ? "100%" : undefined,
-          padding: isUser ? (isEditing ? 0 : "10px 16px") : "0 2px",
-          borderRadius: isUser ? (isEditing ? 0 : 16) : 0,
-          ...(isUser && !isEditing
-            ? {
-                backgroundColor: isDark
-                  ? "rgba(255,255,255,0.08)"
-                  : "rgba(0,0,0,0.05)",
-              }
-            : {}),
-          fontSize: 14,
-          fontFamily: theme?.font?.fontFamily || "inherit",
-          color: theme?.color || "#222",
-          lineHeight: 1.6,
-          wordBreak: "break-word",
-        }}
-      >
-        {isUser ? (
-          <UserMessageBody
-            message={message}
-            isDark={isDark}
-            isEditing={isEditing}
-            userAttachments={userAttachments}
-            editTextareaRef={editTextareaRef}
-            editDraft={editDraft}
-            setEditDraft={setEditDraft}
-            handleEditKeyDown={handleEditKeyDown}
-            handleCancelEdit={handleCancelEdit}
-            handleSubmitEdit={handleSubmitEdit}
-            isSubmitDisabled={isSubmitDisabled}
-            disableActionButtons={disableActionButtons}
-            color={color}
-          />
-        ) : (
-          <AssistantMessageBody
-            message={message}
-            isRawTextMode={isRawTextMode}
-            theme={theme}
-          />
+      {isAssistant &&
+        traceFrames.length === 0 &&
+        message.status === "streaming" && (
+          <TraceChain frames={[]} status={message.status} />
         )}
-      </div>
+
+      {/* Hide the assistant bubble body entirely when streaming with
+          an active trace timeline (intermediate + streaming content shows
+          in the timeline; the bubble only shows the final result). */}
+      {!(
+        isAssistant &&
+        traceFrames.length > 0 &&
+        message.status === "streaming"
+      ) && (
+        <div
+          style={{
+            maxWidth: isUser ? "75%" : "100%",
+            width: isUser && isEditing ? "100%" : undefined,
+            padding: isUser ? (isEditing ? 0 : "10px 16px") : "0 2px",
+            borderRadius: isUser ? (isEditing ? 0 : 16) : 0,
+            ...(isUser && !isEditing
+              ? {
+                  backgroundColor: isDark
+                    ? "rgba(255,255,255,0.08)"
+                    : "rgba(0,0,0,0.05)",
+                }
+              : {}),
+            fontSize: 14,
+            fontFamily: theme?.font?.fontFamily || "inherit",
+            color: theme?.color || "#222",
+            lineHeight: 1.6,
+            wordBreak: "break-word",
+          }}
+        >
+          {isUser ? (
+            <UserMessageBody
+              message={message}
+              isDark={isDark}
+              isEditing={isEditing}
+              userAttachments={userAttachments}
+              editTextareaRef={editTextareaRef}
+              editDraft={editDraft}
+              setEditDraft={setEditDraft}
+              handleEditKeyDown={handleEditKeyDown}
+              handleCancelEdit={handleCancelEdit}
+              handleSubmitEdit={handleSubmitEdit}
+              isSubmitDisabled={isSubmitDisabled}
+              disableActionButtons={disableActionButtons}
+              color={color}
+            />
+          ) : (
+            <AssistantMessageBody
+              message={message}
+              isRawTextMode={isRawTextMode}
+              theme={theme}
+              hasTraceFrames={traceFrames.length > 0}
+            />
+          )}
+        </div>
+      )}
 
       <MessageActionBar
         showActionBar={showActionBar}

--- a/src/COMPONENTs/chat-bubble/components/assistant_message_body.js
+++ b/src/COMPONENTs/chat-bubble/components/assistant_message_body.js
@@ -1,8 +1,16 @@
 import Markdown from "../../../BUILTIN_COMPONENTs/markdown/markdown";
 import CellSplitSpinner from "../../../BUILTIN_COMPONENTs/spinner/cell_split_spinner";
 
-const AssistantMessageBody = ({ message, isRawTextMode, theme }) => {
+const AssistantMessageBody = ({
+  message,
+  isRawTextMode,
+  theme,
+  hasTraceFrames = false,
+}) => {
+  // When timeline is already visible (has trace frames), skip the spinner —
+  // the TraceChain "Thinking…" indicator is enough.
   if (message.status === "streaming" && !message.content) {
+    if (hasTraceFrames) return null;
     return (
       <div style={{ padding: "8px 0" }}>
         <CellSplitSpinner

--- a/src/COMPONENTs/chat-bubble/trace_chain.js
+++ b/src/COMPONENTs/chat-bubble/trace_chain.js
@@ -12,6 +12,7 @@ const DISPLAY_FRAME_TYPES = new Set([
   "observation",
   "tool_call",
   "tool_result",
+  "final_message",
   "error",
 ]);
 
@@ -205,7 +206,7 @@ const ErrorPoint = () => (
 
 /* ─── TraceChain ─────────────────────────────────────────────────────────── */
 
-const TraceChain = ({ frames = [], status }) => {
+const TraceChain = ({ frames = [], status, streamingContent = "" }) => {
   const { theme, onThemeMode } = useContext(ConfigContext);
   const isDark = onThemeMode === "dark_mode";
   const color = theme?.color || "#222";
@@ -213,7 +214,77 @@ const TraceChain = ({ frames = [], status }) => {
 
   const isStreaming = status === "streaming";
 
-  const displayFrames = frames.filter((f) => DISPLAY_FRAME_TYPES.has(f.type));
+  // Identify which final_message frames are "intermediate" (not the very last
+  // one when the stream is finished). During streaming every final_message is
+  // considered intermediate because more content may follow. Once done, all
+  // but the last final_message are intermediate — the last one is rendered by
+  // the normal AssistantMessageBody bubble instead.
+  const intermediateFinalMessageSeqs = useMemo(() => {
+    const hasToolCall = frames.some((frame) => frame?.type === "tool_call");
+    if (!hasToolCall) {
+      return new Set();
+    }
+
+    const finalMessageFrames = frames
+      .filter(
+        (frame) =>
+          frame?.type === "final_message" &&
+          typeof frame.payload?.content === "string" &&
+          frame.payload.content.trim().length > 0,
+      )
+      .sort((left, right) => {
+        const leftSeq = Number(left?.seq);
+        const rightSeq = Number(right?.seq);
+        const leftHasSeq = Number.isFinite(leftSeq);
+        const rightHasSeq = Number.isFinite(rightSeq);
+        if (leftHasSeq && rightHasSeq && leftSeq !== rightSeq) {
+          return leftSeq - rightSeq;
+        }
+
+        const leftTs = Number(left?.ts);
+        const rightTs = Number(right?.ts);
+        const leftHasTs = Number.isFinite(leftTs);
+        const rightHasTs = Number.isFinite(rightTs);
+        if (leftHasTs && rightHasTs && leftTs !== rightTs) {
+          return leftTs - rightTs;
+        }
+
+        return 0;
+      });
+
+    if (finalMessageFrames.length === 0) {
+      return new Set();
+    }
+
+    // While streaming, show ALL final_messages in the timeline (more may come).
+    // Once done, keep all except the very last one (which lives in the bubble).
+    const included = isStreaming
+      ? finalMessageFrames
+      : finalMessageFrames.slice(0, -1);
+
+    return new Set(
+      included
+        .map((frame) => Number(frame.seq))
+        .filter((seq) => Number.isFinite(seq)),
+    );
+  }, [frames, isStreaming]);
+
+  const displayFrames = useMemo(
+    () =>
+      frames.filter((frame) => {
+        if (!DISPLAY_FRAME_TYPES.has(frame.type)) {
+          return false;
+        }
+
+        if (frame.type !== "final_message") {
+          return true;
+        }
+
+        const seq = Number(frame.seq);
+        return Number.isFinite(seq) && intermediateFinalMessageSeqs.has(seq);
+      }),
+    [frames, intermediateFinalMessageSeqs],
+  );
   const startFrame = frames.find((f) => f.type === "stream_started");
   const doneFrame = frames.find((f) => f.type === "done");
   const duration =
@@ -324,23 +395,70 @@ const TraceChain = ({ frames = [], status }) => {
             />
           ),
         });
+      } else if (frame.type === "final_message") {
+        const content =
+          typeof frame.payload?.content === "string"
+            ? frame.payload.content.trim()
+            : "";
+        if (!content) continue;
+        items.push({
+          key: `${frame.seq}-final-message`,
+          title: "Response",
+          span: spanText,
+          status: "done",
+          body: (
+            <div style={{ fontFamily: "inherit" }}>
+              <Markdown
+                markdown={content}
+                options={{
+                  fontSize: 13,
+                  lineHeight: 1.6,
+                }}
+              />
+            </div>
+          ),
+        });
       }
     }
 
     if (isStreaming) {
-      items.push({
-        key: "__streaming__",
-        title: "Thinking…",
-        span: null,
-        status: "active",
-        point: "loading",
-      });
+      const liveContent =
+        typeof streamingContent === "string" ? streamingContent.trim() : "";
+      if (liveContent) {
+        items.push({
+          key: "__streaming_content__",
+          title: "Response",
+          span: null,
+          status: "active",
+          point: "loading",
+          body: (
+            <div style={{ fontFamily: "inherit" }}>
+              <Markdown
+                markdown={liveContent}
+                options={{
+                  fontSize: 13,
+                  lineHeight: 1.6,
+                }}
+              />
+            </div>
+          ),
+        });
+      } else {
+        items.push({
+          key: "__streaming__",
+          title: "Thinking…",
+          span: null,
+          status: "active",
+          point: "loading",
+        });
+      }
     }
 
     return items;
   }, [
     displayFrames,
     isStreaming,
+    streamingContent,
     startFrame,
     toolResultByCallId,
     isDark,

--- a/src/COMPONENTs/chat-bubble/trace_chain.test.js
+++ b/src/COMPONENTs/chat-bubble/trace_chain.test.js
@@ -1,0 +1,181 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import { ConfigContext } from "../../CONTAINERs/config/context";
+import TraceChain from "./trace_chain";
+
+jest.mock("../../BUILTIN_COMPONENTs/icon/icon", () => () => null);
+
+const renderTraceChain = ({ frames, status = "done" }) =>
+  render(
+    <ConfigContext.Provider
+      value={{
+        theme: { color: "#222", font: { fontFamily: "sans-serif" } },
+        onThemeMode: "light_mode",
+      }}
+    >
+      <TraceChain frames={frames} status={status} />
+    </ConfigContext.Provider>,
+  );
+
+const frame = ({ seq, type, payload = {}, ts = seq * 100 }) => ({
+  seq,
+  ts,
+  type,
+  payload,
+});
+
+describe("TraceChain final_message draft timeline", () => {
+  test("shows one Assistant Draft for tool_call + two final_message frames", () => {
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({
+        seq: 2,
+        type: "tool_call",
+        payload: { call_id: "call-1", tool_name: "read_file", arguments: {} },
+      }),
+      frame({
+        seq: 3,
+        type: "tool_result",
+        payload: { call_id: "call-1", result: { content: "file body" } },
+      }),
+      frame({
+        seq: 4,
+        type: "final_message",
+        payload: { content: "intermediate draft content" },
+      }),
+      frame({
+        seq: 5,
+        type: "final_message",
+        payload: { content: "final answer content" },
+      }),
+      frame({ seq: 6, type: "done", payload: {} }),
+    ];
+
+    renderTraceChain({ frames, status: "done" });
+
+    expect(screen.getAllByText("Assistant Draft")).toHaveLength(1);
+    expect(screen.getByText("intermediate draft content")).toBeInTheDocument();
+    expect(screen.queryByText("final answer content")).not.toBeInTheDocument();
+  });
+
+  test("does not show draft when tool_call exists but only one final_message frame", () => {
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({
+        seq: 2,
+        type: "tool_call",
+        payload: { call_id: "call-1", tool_name: "read_file", arguments: {} },
+      }),
+      frame({
+        seq: 3,
+        type: "final_message",
+        payload: { content: "single final content" },
+      }),
+      frame({ seq: 4, type: "done", payload: {} }),
+    ];
+
+    renderTraceChain({ frames, status: "done" });
+
+    expect(screen.queryByText("Assistant Draft")).not.toBeInTheDocument();
+    expect(screen.queryByText("single final content")).not.toBeInTheDocument();
+  });
+
+  test("does not show draft when no tool_call exists", () => {
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({
+        seq: 2,
+        type: "final_message",
+        payload: { content: "candidate draft" },
+      }),
+      frame({
+        seq: 3,
+        type: "final_message",
+        payload: { content: "final answer" },
+      }),
+      frame({ seq: 4, type: "done", payload: {} }),
+    ];
+
+    renderTraceChain({ frames, status: "done" });
+
+    expect(screen.queryByText("Assistant Draft")).not.toBeInTheDocument();
+    expect(screen.queryByText("candidate draft")).not.toBeInTheDocument();
+  });
+
+  test("keeps existing reasoning/tool/error items while inserting draft in sequence", () => {
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({ seq: 2, type: "reasoning", payload: { reasoning: "thinking" } }),
+      frame({
+        seq: 3,
+        type: "tool_call",
+        payload: { call_id: "call-1", tool_name: "read_file", arguments: {} },
+      }),
+      frame({
+        seq: 4,
+        type: "tool_result",
+        payload: { call_id: "call-1", result: { content: "ok" } },
+      }),
+      frame({
+        seq: 5,
+        type: "final_message",
+        payload: { content: "intermediate draft content" },
+      }),
+      frame({
+        seq: 6,
+        type: "final_message",
+        payload: { content: "final answer content" },
+      }),
+      frame({
+        seq: 7,
+        type: "error",
+        payload: { code: "oops", message: "failed" },
+      }),
+    ];
+
+    const { container } = renderTraceChain({ frames, status: "error" });
+
+    expect(screen.getByText("Reasoning")).toBeInTheDocument();
+    expect(screen.getByText("read_file")).toBeInTheDocument();
+    expect(screen.getByText("Error")).toBeInTheDocument();
+    expect(screen.getByText("Assistant Draft")).toBeInTheDocument();
+
+    const timelineText = container.textContent || "";
+    expect(timelineText.indexOf("Reasoning")).toBeLessThan(
+      timelineText.indexOf("Assistant Draft"),
+    );
+    expect(timelineText.indexOf("Assistant Draft")).toBeLessThan(
+      timelineText.indexOf("Error"),
+    );
+  });
+
+  test("in streaming mode, only non-latest final_message appears as draft", () => {
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({
+        seq: 2,
+        type: "tool_call",
+        payload: { call_id: "call-1", tool_name: "read_file", arguments: {} },
+      }),
+      frame({
+        seq: 3,
+        type: "final_message",
+        payload: { content: "older draft" },
+      }),
+      frame({
+        seq: 4,
+        type: "final_message",
+        payload: { content: "latest in-progress answer" },
+      }),
+    ];
+
+    renderTraceChain({ frames, status: "streaming" });
+
+    expect(screen.getAllByText("Assistant Draft")).toHaveLength(1);
+    expect(screen.getByText("older draft")).toBeInTheDocument();
+    expect(
+      screen.queryByText("latest in-progress answer"),
+    ).not.toBeInTheDocument();
+    expect(screen.getAllByText("Thinking…").length).toBeGreaterThan(0);
+  });
+});

--- a/src/PAGEs/chat/chat.js
+++ b/src/PAGEs/chat/chat.js
@@ -895,6 +895,57 @@ const ChatInterface = () => {
                 return;
               }
 
+              // On tool_call, capture any intermediate streamed content
+              // as a synthetic final_message trace frame (if not already
+              // captured by a real final_message), then clear content so
+              // intermediate text lives only in the trace timeline.
+              if (frame.type === "tool_call") {
+                const nextStreamMessages = streamMessages.map((message) => {
+                  if (message.id !== assistantMessageId) return message;
+
+                  const currentContent =
+                    typeof message.content === "string"
+                      ? message.content.trim()
+                      : "";
+                  const existingFrames = message.traceFrames || [];
+
+                  // Check whether the current content was already captured
+                  // by a real final_message frame.
+                  const alreadyCaptured =
+                    !currentContent ||
+                    existingFrames.some(
+                      (f) =>
+                        f.type === "final_message" &&
+                        typeof f.payload?.content === "string" &&
+                        f.payload.content.trim() === currentContent,
+                    );
+
+                  const syntheticFrame = alreadyCaptured
+                    ? []
+                    : [
+                        {
+                          seq:
+                            (Number.isFinite(Number(frame.seq))
+                              ? Number(frame.seq)
+                              : 0) - 0.5,
+                          ts: patchTime,
+                          type: "final_message",
+                          stage: "model",
+                          payload: { content: currentContent },
+                        },
+                      ];
+
+                  return {
+                    ...message,
+                    content: "",
+                    updatedAt: patchTime,
+                    traceFrames: [...existingFrames, ...syntheticFrame, frame],
+                  };
+                });
+                syncStreamMessages(nextStreamMessages);
+                return;
+              }
+
               // All other frames go into the trace timeline
               const nextStreamMessages = streamMessages.map((message) =>
                 message.id === assistantMessageId
@@ -933,9 +984,22 @@ const ChatInterface = () => {
                 }
               }
             },
-            onToken: (_delta) => {
-              // token_delta is not used directly — final reply comes from
-              // the final_message frame via onFrame above.
+            onToken: (delta) => {
+              if (typeof delta !== "string" || !delta) {
+                return;
+              }
+
+              const patchTime = Date.now();
+              const nextStreamMessages = streamMessages.map((message) =>
+                message.id === assistantMessageId
+                  ? {
+                      ...message,
+                      content: `${typeof message.content === "string" ? message.content : ""}${delta}`,
+                      updatedAt: patchTime,
+                    }
+                  : message,
+              );
+              syncStreamMessages(nextStreamMessages);
             },
             onDone: (done) => {
               const doneTime = Date.now();


### PR DESCRIPTION
## Summary

Moves intermediate AI message content into the TraceChain timeline instead of the bottom chat bubble. The bubble now only displays the final response.

## Changes

### Streaming & State (`chat.js`)
- On `tool_call` frame, captures current streamed content as a synthetic `final_message` trace frame (if not already captured by a real one), then clears `message.content`
- Ensures intermediate text is always persisted in `traceFrames` for localStorage saving

### Timeline Rendering (`trace_chain.js`)
- Accepts new `streamingContent` prop for live token display
- `final_message` frames render as non-collapsible Markdown `body` (not collapsible `details`)
- During streaming: shows live content as "Response" item with spinner; shows "Thinking…" when no content yet
- Updated filter: during streaming all `final_message` frames shown in timeline; once done, all except the last

### Chat Bubble (`chat_bubble.js`)
- Passes `streamingContent` to `TraceChain` during streaming
- Hides bubble entirely during streaming with active trace (no duplicate content)

### Assistant Message Body (`assistant_message_body.js`)  
- Returns `null` when trace is active and content is empty (skip redundant spinner)

### Tests
- Added trace frame logic tests