### PR TITLE
feat: add tool confirmation endpoint and related functionality

### DIFF
--- a/miso_runtime/server/miso_adapter.py
+++ b/miso_runtime/server/miso_adapter.py
@@ -9,6 +9,7 @@ import copy
 import sys
 import threading
 import time
+import uuid as _uuid
 from pathlib import Path
 from typing import Any, Dict, Iterable, List
 
@@ -34,6 +35,151 @@ _KNOWN_TOOLKIT_EXPORTS = {
     "mcp": "integration",
 }
 _DEFAULT_MAX_ITERATIONS = 6
+_CONFIRMATION_TIMEOUT_SECONDS = 300
+_CONFIRMATION_REQUIRED_TOOL_NAMES = {
+    "write_file",
+    "delete_file",
+    "move_file",
+    "terminal_exec",
+}
+_pending_confirmations: Dict[str, Dict[str, Any]] = {}
+_pending_confirmations_lock = threading.Lock()
+
+
+def _normalize_tool_confirmation_response(raw: object) -> Dict[str, Any]:
+    approved = True
+    reason = ""
+    modified_arguments: Dict[str, Any] | None = None
+
+    if isinstance(raw, bool):
+        approved = raw
+    elif isinstance(raw, dict):
+        approved = bool(raw.get("approved", True))
+        reason_raw = raw.get("reason", "")
+        reason = reason_raw if isinstance(reason_raw, str) else str(reason_raw or "")
+        modified_raw = raw.get("modified_arguments")
+        if isinstance(modified_raw, dict):
+            modified_arguments = modified_raw
+    else:
+        approved_attr = getattr(raw, "approved", raw)
+        approved = bool(approved_attr)
+        reason_attr = getattr(raw, "reason", "")
+        reason = reason_attr if isinstance(reason_attr, str) else str(reason_attr or "")
+        modified_attr = getattr(raw, "modified_arguments", None)
+        if isinstance(modified_attr, dict):
+            modified_arguments = modified_attr
+
+    return {
+        "approved": approved,
+        "reason": reason,
+        "modified_arguments": modified_arguments,
+    }
+
+
+def _build_tool_confirmation_request_payload(request_obj: object) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {}
+    if isinstance(request_obj, dict):
+        payload = dict(request_obj)
+    else:
+        to_dict = getattr(request_obj, "to_dict", None)
+        if callable(to_dict):
+            try:
+                raw_payload = to_dict()
+                if isinstance(raw_payload, dict):
+                    payload = dict(raw_payload)
+            except Exception:
+                payload = {}
+
+    if not payload:
+        payload = {
+            "tool_name": getattr(request_obj, "tool_name", ""),
+            "call_id": getattr(request_obj, "call_id", ""),
+            "arguments": getattr(request_obj, "arguments", {}),
+            "description": getattr(request_obj, "description", ""),
+        }
+
+    payload["type"] = "tool_confirmation_request"
+
+    if not isinstance(payload.get("tool_name"), str):
+        payload["tool_name"] = str(payload.get("tool_name", "") or "")
+    if not isinstance(payload.get("call_id"), str):
+        payload["call_id"] = str(payload.get("call_id", "") or "")
+
+    arguments = payload.get("arguments")
+    payload["arguments"] = arguments if isinstance(arguments, dict) else {}
+
+    description = payload.get("description", "")
+    payload["description"] = description if isinstance(description, str) else str(description or "")
+
+    return payload
+
+
+def submit_tool_confirmation(
+    confirmation_id: str,
+    approved: bool,
+    reason: str = "",
+    modified_arguments: Dict[str, Any] | None = None,
+) -> bool:
+    normalized_id = confirmation_id.strip() if isinstance(confirmation_id, str) else ""
+    if not normalized_id:
+        return False
+
+    with _pending_confirmations_lock:
+        pending = _pending_confirmations.get(normalized_id)
+        if pending is None:
+            return False
+
+        pending["response"] = {
+            "approved": bool(approved),
+            "reason": reason if isinstance(reason, str) else str(reason or ""),
+            "modified_arguments": modified_arguments if isinstance(modified_arguments, dict) else None,
+        }
+        event = pending.get("event")
+        if isinstance(event, threading.Event):
+            event.set()
+
+    return True
+
+
+def _make_tool_confirm_callback(
+    emit_event,
+    timeout_seconds: int = _CONFIRMATION_TIMEOUT_SECONDS,
+):
+    safe_timeout_seconds = max(1, int(timeout_seconds))
+
+    def on_tool_confirm(request_obj: object) -> Dict[str, Any]:
+        confirmation_id = str(_uuid.uuid4())
+        waiter = {"event": threading.Event(), "response": None}
+
+        with _pending_confirmations_lock:
+            _pending_confirmations[confirmation_id] = waiter
+
+        try:
+            request_payload = _build_tool_confirmation_request_payload(request_obj)
+            request_payload["confirmation_id"] = confirmation_id
+            emit_event(request_payload)
+            waiter["event"].wait(timeout=safe_timeout_seconds)
+        except Exception as callback_error:
+            return {
+                "approved": False,
+                "reason": f"Failed to request confirmation: {callback_error}",
+                "modified_arguments": None,
+            }
+        finally:
+            with _pending_confirmations_lock:
+                _pending_confirmations.pop(confirmation_id, None)
+
+        response = waiter.get("response")
+        if isinstance(response, dict):
+            return _normalize_tool_confirmation_response(response)
+
+        return {
+            "approved": False,
+            "reason": "Confirmation timed out",
+            "modified_arguments": None,
+        }
+
+    return on_tool_confirm
 
 
 def _is_valid_miso_source(path: Path) -> bool:
@@ -118,6 +264,18 @@ def _apply_broth_runtime_patches(broth_cls: Any) -> None:
     ):
         return
 
+    try:
+        execute_tool_calls_params = inspect.signature(original_execute_tool_calls).parameters
+        original_supports_on_tool_confirm = (
+            "on_tool_confirm" in execute_tool_calls_params
+            or any(
+                parameter.kind == inspect.Parameter.VAR_KEYWORD
+                for parameter in execute_tool_calls_params.values()
+            )
+        )
+    except Exception:
+        original_supports_on_tool_confirm = True
+
     def _patched_execute_tool_calls(
         self,
         *,
@@ -125,14 +283,20 @@ def _apply_broth_runtime_patches(broth_cls: Any) -> None:
         run_id: str,
         iteration: int,
         callback,
+        on_tool_confirm=None,
     ):
         if getattr(self, "provider", "") != "anthropic":
+            original_kwargs = {
+                "tool_calls": tool_calls,
+                "run_id": run_id,
+                "iteration": iteration,
+                "callback": callback,
+            }
+            if original_supports_on_tool_confirm:
+                original_kwargs["on_tool_confirm"] = on_tool_confirm
             return original_execute_tool_calls(
                 self,
-                tool_calls=tool_calls,
-                run_id=run_id,
-                iteration=iteration,
-                callback=callback,
+                **original_kwargs,
             )
 
         result_messages: List[Dict[str, Any]] = []
@@ -153,7 +317,57 @@ def _apply_broth_runtime_patches(broth_cls: Any) -> None:
                 arguments=tool_call.arguments,
             )
 
-            tool_result = self._execute_from_toolkits(tool_call.name, tool_call.arguments)
+            tool_obj = self._find_tool(tool_call.name)
+            effective_arguments = tool_call.arguments
+            denied = False
+            deny_reason = ""
+
+            if (
+                tool_obj is not None
+                and bool(getattr(tool_obj, "requires_confirmation", False))
+                and on_tool_confirm is not None
+            ):
+                confirmation_request = {
+                    "tool_name": tool_call.name,
+                    "call_id": tool_call.call_id,
+                    "arguments": tool_call.arguments if isinstance(tool_call.arguments, dict) else {},
+                    "description": str(getattr(tool_obj, "description", "") or ""),
+                }
+                raw_response = on_tool_confirm(confirmation_request)
+                response = _normalize_tool_confirmation_response(raw_response)
+
+                if not response["approved"]:
+                    denied = True
+                    deny_reason = str(response.get("reason", "") or "")
+                    self._emit(
+                        callback,
+                        "tool_denied",
+                        run_id,
+                        iteration=iteration,
+                        tool_name=tool_call.name,
+                        call_id=tool_call.call_id,
+                        reason=deny_reason,
+                    )
+                else:
+                    if response.get("modified_arguments") is not None:
+                        effective_arguments = response["modified_arguments"]
+                    self._emit(
+                        callback,
+                        "tool_confirmed",
+                        run_id,
+                        iteration=iteration,
+                        tool_name=tool_call.name,
+                        call_id=tool_call.call_id,
+                    )
+
+            if denied:
+                tool_result = {
+                    "denied": True,
+                    "tool": tool_call.name,
+                    "reason": deny_reason or "User denied execution.",
+                }
+            else:
+                tool_result = self._execute_from_toolkits(tool_call.name, effective_arguments)
             content = json.dumps(tool_result, default=str, ensure_ascii=False)
 
             anthropic_tool_results.append(
@@ -1014,6 +1228,21 @@ def _resolve_workspace_root(workspace_root: str) -> Path:
     return candidate
 
 
+def _mark_workspace_tools_for_confirmation(workspace_toolkit: Any) -> None:
+    tools = getattr(workspace_toolkit, "tools", None)
+    if not isinstance(tools, dict):
+        return
+
+    for tool_name in _CONFIRMATION_REQUIRED_TOOL_NAMES:
+        tool_obj = tools.get(tool_name)
+        if tool_obj is None:
+            continue
+        try:
+            tool_obj.requires_confirmation = True
+        except Exception:
+            continue
+
+
 def _attach_workspace_toolkit(agent: Any, options: Dict[str, object] | None = None) -> None:
     workspace_root_raw = _extract_workspace_root_from_options(options)
     if not workspace_root_raw:
@@ -1044,6 +1273,7 @@ def _attach_workspace_toolkit(agent: Any, options: Dict[str, object] | None = No
         # Backward compatibility for older signatures.
         workspace_toolkit = toolkit_factory(workspace_root=str(workspace_root))
 
+    _mark_workspace_tools_for_confirmation(workspace_toolkit)
     agent.add_toolkit(workspace_toolkit)
 
 
@@ -1235,14 +1465,29 @@ def stream_chat_events(
             output_holder["last_iteration"] = iteration
         event_queue.put(event)
 
+    confirm_cb = _make_tool_confirm_callback(
+        lambda event: event_queue.put(event),
+        timeout_seconds=_CONFIRMATION_TIMEOUT_SECONDS,
+    )
+
     def run_agent() -> None:
         try:
-            messages_out, _bundle = agent.run(
-                messages=messages,
-                payload=payload,
-                callback=on_event,
-                max_iterations=agent.max_iterations,
-            )
+            run_kwargs: Dict[str, Any] = {
+                "messages": messages,
+                "payload": payload,
+                "callback": on_event,
+                "max_iterations": agent.max_iterations,
+            }
+
+            try:
+                run_params = inspect.signature(agent.run).parameters
+            except Exception:
+                run_params = {}
+
+            if "on_tool_confirm" in run_params:
+                run_kwargs["on_tool_confirm"] = confirm_cb
+
+            messages_out, _bundle = agent.run(**run_kwargs)
             output_holder["messages"] = messages_out
         except Exception as run_error:  # pragma: no cover
             output_holder["error"] = run_error

--- a/miso_runtime/server/routes.py
+++ b/miso_runtime/server/routes.py
@@ -11,6 +11,7 @@ from miso_adapter import (
     get_model_name,
     get_runtime_config,
     get_toolkit_catalog,
+    submit_tool_confirmation,
     stream_chat,
     stream_chat_events,
 )
@@ -36,6 +37,9 @@ _TRACE_STAGE_BY_EVENT_TYPE = {
     "token_delta": "model",
     "final_message": "model",
     "tool_call": "tool",
+    "tool_confirmation_request": "tool",
+    "tool_confirmed": "tool",
+    "tool_denied": "tool",
     "tool_result": "tool",
     "error": "stream",
     "done": "stream",
@@ -315,6 +319,69 @@ def toolkits_catalog() -> Response:
         ), 401
 
     return jsonify(get_toolkit_catalog())
+
+
+@api_blueprint.post("/chat/tool/confirmation")
+def chat_tool_confirmation() -> Response:
+    if not _is_authorized():
+        return jsonify(
+            {
+                "error": {
+                    "code": "unauthorized",
+                    "message": "Invalid auth token",
+                }
+            }
+        ), 401
+
+    payload = request.get_json(silent=True) or {}
+    confirmation_id_raw = payload.get("confirmation_id")
+    confirmation_id = (
+        confirmation_id_raw.strip()
+        if isinstance(confirmation_id_raw, str)
+        else ""
+    )
+    if not confirmation_id:
+        return jsonify(
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "confirmation_id is required",
+                }
+            }
+        ), 400
+
+    approved = bool(payload.get("approved", False))
+    reason_raw = payload.get("reason", "")
+    reason = reason_raw if isinstance(reason_raw, str) else str(reason_raw or "")
+
+    modified_arguments = payload.get("modified_arguments")
+    if modified_arguments is not None and not isinstance(modified_arguments, dict):
+        return jsonify(
+            {
+                "error": {
+                    "code": "invalid_request",
+                    "message": "modified_arguments must be an object when provided",
+                }
+            }
+        ), 400
+
+    found = submit_tool_confirmation(
+        confirmation_id=confirmation_id,
+        approved=approved,
+        reason=reason,
+        modified_arguments=modified_arguments,
+    )
+    if not found:
+        return jsonify(
+            {
+                "error": {
+                    "code": "not_found",
+                    "message": "No pending confirmation found for this ID",
+                }
+            }
+        ), 404
+
+    return jsonify({"status": "ok"})
 
 
 @api_blueprint.post("/chat/stream")

--- a/miso_runtime/server/tests/test_miso_adapter_capabilities.py
+++ b/miso_runtime/server/tests/test_miso_adapter_capabilities.py
@@ -1,6 +1,8 @@
 import json
 import sys
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -197,13 +199,12 @@ class MisoAdapterCapabilityCatalogTests(unittest.TestCase):
         self.assertEqual(
             names,
             [
-                "toolkit",
                 "builtin_toolkit",
                 "python_workspace_toolkit",
                 "mcp",
             ],
         )
-        self.assertEqual(catalog["count"], 4)
+        self.assertEqual(catalog["count"], 3)
 
     def test_get_toolkit_catalog_returns_empty_when_toolkit_base_unavailable(self) -> None:
         with mock.patch.object(miso_adapter, "_resolve_toolkit_base", return_value=None):
@@ -243,6 +244,81 @@ class MisoAdapterCapabilityCatalogTests(unittest.TestCase):
             miso_adapter._extract_max_iterations_from_options({"maxIterations": "abc"})
         )
         self.assertIsNone(miso_adapter._extract_max_iterations_from_options({}))
+
+    def test_make_tool_confirm_callback_round_trip_with_submit(self) -> None:
+        emitted_events = []
+        confirm_cb = miso_adapter._make_tool_confirm_callback(
+            emitted_events.append,
+            timeout_seconds=2,
+        )
+        response_holder: dict[str, object] = {}
+
+        def invoke_callback() -> None:
+            response_holder["value"] = confirm_cb(
+                SimpleNamespace(
+                    tool_name="delete_file",
+                    call_id="call-1",
+                    arguments={"path": "tmp.txt"},
+                    description="Delete a file",
+                )
+            )
+
+        worker = threading.Thread(target=invoke_callback, daemon=True)
+        worker.start()
+
+        deadline = time.time() + 2
+        while not emitted_events and time.time() < deadline:
+            time.sleep(0.01)
+
+        self.assertTrue(emitted_events)
+        request_event = emitted_events[0]
+        self.assertEqual(request_event.get("type"), "tool_confirmation_request")
+        confirmation_id = request_event.get("confirmation_id")
+        self.assertIsInstance(confirmation_id, str)
+
+        submitted = miso_adapter.submit_tool_confirmation(
+            confirmation_id=confirmation_id,
+            approved=True,
+            reason="approved",
+        )
+        self.assertTrue(submitted)
+
+        worker.join(timeout=2)
+        self.assertFalse(worker.is_alive())
+
+        result = response_holder.get("value")
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result["approved"], True)
+        self.assertEqual(result["reason"], "approved")
+
+    def test_make_tool_confirm_callback_times_out_to_denied_response(self) -> None:
+        confirm_cb = miso_adapter._make_tool_confirm_callback(
+            lambda _event: None,
+            timeout_seconds=1,
+        )
+
+        started = time.time()
+        result = confirm_cb(
+            {
+                "tool_name": "delete_file",
+                "call_id": "call-timeout",
+                "arguments": {"path": "tmp.txt"},
+                "description": "Delete a file",
+            }
+        )
+        elapsed = time.time() - started
+
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get("approved"), False)
+        self.assertIn("timed out", str(result.get("reason", "")).lower())
+        self.assertLess(elapsed, 2.5)
+
+    def test_submit_tool_confirmation_returns_false_for_unknown_id(self) -> None:
+        submitted = miso_adapter.submit_tool_confirmation(
+            confirmation_id="unknown-confirmation-id",
+            approved=True,
+        )
+        self.assertFalse(submitted)
 
     def test_apply_broth_runtime_patches_batches_anthropic_tool_results(self) -> None:
         class FakeBroth:
@@ -343,6 +419,87 @@ class MisoAdapterCapabilityCatalogTests(unittest.TestCase):
         )
         self.assertTrue(agent.used_original_execute)
 
+    def test_apply_broth_runtime_patches_anthropic_confirmation_gate(self) -> None:
+        class FakeBroth:
+            def __init__(self):
+                self.provider = "anthropic"
+                self.executed_arguments = []
+                self.events = []
+
+            def _execute_tool_calls(self, **_kwargs):
+                return [{"role": "tool", "content": "original"}], False
+
+            def _build_observation_messages(self, full_messages, tool_messages):
+                return [*full_messages, *tool_messages]
+
+            def _inject_observation(self, _tool_message, _observation):
+                return None
+
+            def _emit(self, _callback, event_type, _run_id, *, iteration, **extra):
+                self.events.append((event_type, iteration, extra))
+
+            def _find_tool(self, _name):
+                return SimpleNamespace(
+                    observe=False,
+                    requires_confirmation=True,
+                    description="dangerous",
+                )
+
+            def _execute_from_toolkits(self, name, arguments):
+                self.executed_arguments.append((name, arguments))
+                return {"ok": True, "arguments": arguments}
+
+        miso_adapter._apply_broth_runtime_patches(FakeBroth)
+
+        agent = FakeBroth()
+        denied_messages, _ = agent._execute_tool_calls(
+            tool_calls=[
+                SimpleNamespace(
+                    call_id="call-deny",
+                    name="delete_file",
+                    arguments={"path": "a.txt"},
+                )
+            ],
+            run_id="run-1",
+            iteration=0,
+            callback=None,
+            on_tool_confirm=lambda _req: {"approved": False, "reason": "no"},
+        )
+
+        self.assertEqual(agent.executed_arguments, [])
+        denied_events = [event for event in agent.events if event[0] == "tool_denied"]
+        self.assertEqual(len(denied_events), 1)
+        denied_content = denied_messages[0]["content"][0]["content"]
+        denied_result = json.loads(denied_content)
+        self.assertEqual(denied_result["denied"], True)
+
+        approved_messages, _ = agent._execute_tool_calls(
+            tool_calls=[
+                SimpleNamespace(
+                    call_id="call-approve",
+                    name="move_file",
+                    arguments={"source": "a.txt", "destination": "b.txt"},
+                )
+            ],
+            run_id="run-2",
+            iteration=1,
+            callback=None,
+            on_tool_confirm=lambda _req: {
+                "approved": True,
+                "modified_arguments": {"source": "x.txt", "destination": "y.txt"},
+            },
+        )
+
+        self.assertEqual(
+            agent.executed_arguments[-1],
+            ("move_file", {"source": "x.txt", "destination": "y.txt"}),
+        )
+        confirmed_events = [event for event in agent.events if event[0] == "tool_confirmed"]
+        self.assertEqual(len(confirmed_events), 1)
+        approved_content = approved_messages[0]["content"][0]["content"]
+        approved_result = json.loads(approved_content)
+        self.assertEqual(approved_result["ok"], True)
+
     def test_create_agent_skips_workspace_toolkit_when_workspace_root_missing(self) -> None:
         class FakeAgent:
             def __init__(self):
@@ -404,6 +561,54 @@ class MisoAdapterCapabilityCatalogTests(unittest.TestCase):
         self.assertEqual(len(agent.toolkits), 1)
         self.assertEqual(captured["workspace_root"], str(Path(tmp).resolve()))
         self.assertEqual(captured["include_python_runtime"], True)
+
+    def test_create_agent_marks_selected_workspace_tools_requires_confirmation(self) -> None:
+        class FakeAgent:
+            def __init__(self):
+                self.toolkits = []
+                self.provider = ""
+                self.model = ""
+                self.max_iterations = 0
+
+            def add_toolkit(self, toolkit):
+                self.toolkits.append(toolkit)
+
+        class FakeTool:
+            def __init__(self):
+                self.requires_confirmation = False
+
+        toolkit_instance = SimpleNamespace(
+            tools={
+                "write_file": FakeTool(),
+                "delete_file": FakeTool(),
+                "move_file": FakeTool(),
+                "terminal_exec": FakeTool(),
+                "read_file": FakeTool(),
+            }
+        )
+
+        def fake_workspace_toolkit(*, workspace_root=None, include_python_runtime=True):
+            return toolkit_instance
+
+        with tempfile.TemporaryDirectory() as tmp:
+            with mock.patch.object(
+                miso_adapter, "_BROTH_CLASS", FakeAgent
+            ), mock.patch.object(
+                miso_adapter, "_IMPORT_ERROR", None
+            ), mock.patch.object(
+                miso_adapter.importlib,
+                "import_module",
+                return_value=SimpleNamespace(
+                    python_workspace_toolkit=fake_workspace_toolkit
+                ),
+            ):
+                _agent = miso_adapter._create_agent({"workspace_root": tmp})
+
+        self.assertTrue(toolkit_instance.tools["write_file"].requires_confirmation)
+        self.assertTrue(toolkit_instance.tools["delete_file"].requires_confirmation)
+        self.assertTrue(toolkit_instance.tools["move_file"].requires_confirmation)
+        self.assertTrue(toolkit_instance.tools["terminal_exec"].requires_confirmation)
+        self.assertFalse(toolkit_instance.tools["read_file"].requires_confirmation)
 
     def test_create_agent_rejects_invalid_workspace_root(self) -> None:
         class FakeAgent:
@@ -502,6 +707,53 @@ class MisoAdapterCapabilityCatalogTests(unittest.TestCase):
             agent = miso_adapter._create_agent({"maxIterations": 5})
 
         self.assertEqual(agent.max_iterations, 5)
+
+    def test_stream_chat_events_passes_on_tool_confirm_to_agent_run(self) -> None:
+        class FakeAgent:
+            def __init__(self):
+                self.provider = "openai"
+                self.max_iterations = 3
+                self.received_on_tool_confirm = False
+
+            def run(
+                self,
+                messages,
+                payload=None,
+                callback=None,
+                max_iterations=None,
+                on_tool_confirm=None,
+            ):
+                self.received_on_tool_confirm = callable(on_tool_confirm)
+                if callable(callback):
+                    callback(
+                        {
+                            "type": "final_message",
+                            "run_id": "run-1",
+                            "iteration": 0,
+                            "timestamp": time.time(),
+                            "content": "done",
+                        }
+                    )
+                return [{"role": "assistant", "content": "done"}], {}
+
+        fake_agent = FakeAgent()
+
+        with mock.patch.object(
+            miso_adapter,
+            "_create_agent",
+            return_value=fake_agent,
+        ):
+            events = list(
+                miso_adapter.stream_chat_events(
+                    message="hello",
+                    history=[],
+                    attachments=[],
+                    options={},
+                )
+            )
+
+        self.assertTrue(fake_agent.received_on_tool_confirm)
+        self.assertTrue(any(event.get("type") == "final_message" for event in events))
 
     def test_extract_last_assistant_text_handles_structured_content(self) -> None:
         messages = [

--- a/miso_runtime/server/tests/test_models_catalog_route.py
+++ b/miso_runtime/server/tests/test_models_catalog_route.py
@@ -168,6 +168,75 @@ class ModelsCatalogRouteTests(unittest.TestCase):
             "message or attachments is required",
         )
 
+    def test_chat_tool_confirmation_accepts_pending_confirmation(self) -> None:
+        with mock.patch.object(
+            miso_routes,
+            "submit_tool_confirmation",
+            return_value=True,
+        ) as submit_mock:
+            response = self.client.post(
+                "/chat/tool/confirmation",
+                json={
+                    "confirmation_id": "confirm-1",
+                    "approved": True,
+                    "reason": "looks good",
+                },
+            )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json(), {"status": "ok"})
+        submit_mock.assert_called_once_with(
+            confirmation_id="confirm-1",
+            approved=True,
+            reason="looks good",
+            modified_arguments=None,
+        )
+
+    def test_chat_tool_confirmation_returns_not_found_when_missing(self) -> None:
+        with mock.patch.object(
+            miso_routes,
+            "submit_tool_confirmation",
+            return_value=False,
+        ):
+            response = self.client.post(
+                "/chat/tool/confirmation",
+                json={
+                    "confirmation_id": "missing-id",
+                    "approved": False,
+                },
+            )
+
+        self.assertEqual(response.status_code, 404)
+        payload = response.get_json()
+        self.assertEqual(payload["error"]["code"], "not_found")
+
+    def test_chat_tool_confirmation_validates_payload(self) -> None:
+        missing_id_response = self.client.post(
+            "/chat/tool/confirmation",
+            json={
+                "approved": True,
+            },
+        )
+        self.assertEqual(missing_id_response.status_code, 400)
+        self.assertEqual(
+            missing_id_response.get_json()["error"]["message"],
+            "confirmation_id is required",
+        )
+
+        invalid_modified_arguments_response = self.client.post(
+            "/chat/tool/confirmation",
+            json={
+                "confirmation_id": "confirm-2",
+                "approved": True,
+                "modified_arguments": "not-a-dict",
+            },
+        )
+        self.assertEqual(invalid_modified_arguments_response.status_code, 400)
+        self.assertEqual(
+            invalid_modified_arguments_response.get_json()["error"]["message"],
+            "modified_arguments must be an object when provided",
+        )
+
     def test_chat_stream_v2_emits_trace_frames(self) -> None:
         mocked_events = iter(
             [

--- a/public/electron.js
+++ b/public/electron.js
@@ -76,6 +76,7 @@ const MISO_HEALTH_RETRY_MS = 250;
 const MISO_RESTART_DELAY_MS = 1500;
 const MISO_STREAM_ENDPOINT = "/chat/stream";
 const MISO_STREAM_V2_ENDPOINT = "/chat/stream/v2";
+const MISO_TOOL_CONFIRMATION_ENDPOINT = "/chat/tool/confirmation";
 const MISO_HEALTH_ENDPOINT = "/health";
 const MISO_MODELS_CATALOG_ENDPOINT = "/models/catalog";
 const MISO_TOOLKIT_CATALOG_ENDPOINT = "/toolkits/catalog";
@@ -444,6 +445,82 @@ const getMisoToolkitCatalogPayload = async () => {
     return JSON.parse(bodyText);
   } catch (_) {
     throw new Error("Invalid Miso toolkit catalog response");
+  }
+};
+
+const submitMisoToolConfirmation = async (payload = {}) => {
+  if (misoStatus !== "ready" || !misoPort) {
+    const reasonSuffix =
+      typeof misoStatusReason === "string" && misoStatusReason.trim()
+        ? `, reason=${misoStatusReason.trim()}`
+        : "";
+    throw new Error(
+      `Miso service is not ready (status=${misoStatus}${reasonSuffix})`,
+    );
+  }
+
+  const confirmationIdRaw = payload?.confirmation_id;
+  const confirmationId =
+    typeof confirmationIdRaw === "string" ? confirmationIdRaw.trim() : "";
+  if (!confirmationId) {
+    throw new Error("confirmation_id is required");
+  }
+
+  const reasonRaw = payload?.reason;
+  const requestBody = {
+    confirmation_id: confirmationId,
+    approved: Boolean(payload?.approved),
+    reason: typeof reasonRaw === "string" ? reasonRaw : String(reasonRaw || ""),
+  };
+
+  const modifiedArguments = payload?.modified_arguments;
+  if (modifiedArguments != null) {
+    const isObject =
+      typeof modifiedArguments === "object" &&
+      !Array.isArray(modifiedArguments);
+    if (!isObject) {
+      throw new Error("modified_arguments must be an object");
+    }
+    requestBody.modified_arguments = modifiedArguments;
+  }
+
+  const response = await fetch(
+    `http://${MISO_HOST}:${misoPort}${MISO_TOOL_CONFIRMATION_ENDPOINT}`,
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(misoAuthToken ? { "x-miso-auth": misoAuthToken } : {}),
+      },
+      body: JSON.stringify(requestBody),
+    },
+  );
+
+  const bodyText = await response.text();
+  if (!response.ok) {
+    let message = `Miso tool confirmation request failed (${response.status})`;
+    if (bodyText) {
+      try {
+        const parsed = JSON.parse(bodyText);
+        const serverMessage = parsed?.error?.message || parsed?.message;
+        if (serverMessage) {
+          message = String(serverMessage);
+        }
+      } catch (_) {
+        message = bodyText.slice(0, 200);
+      }
+    }
+    throw new Error(message);
+  }
+
+  if (!bodyText) {
+    return { status: "ok" };
+  }
+
+  try {
+    return JSON.parse(bodyText);
+  } catch (_) {
+    throw new Error("Invalid Miso tool confirmation response");
   }
 };
 
@@ -1251,6 +1328,9 @@ ipcMain.handle("miso:get-model-catalog", async () =>
 );
 ipcMain.handle("miso:get-toolkit-catalog", async () =>
   getMisoToolkitCatalogPayload(),
+);
+ipcMain.handle("miso:tool-confirmation", async (_event, payload = {}) =>
+  submitMisoToolConfirmation(payload),
 );
 ipcMain.handle(
   "miso:pick-workspace-root",

--- a/public/preload.js
+++ b/public/preload.js
@@ -198,6 +198,8 @@ contextBridge.exposeInMainWorld("misoAPI", {
   getStatus: () => ipcRenderer.invoke("miso:get-status"),
   getModelCatalog: () => ipcRenderer.invoke("miso:get-model-catalog"),
   getToolkitCatalog: () => ipcRenderer.invoke("miso:get-toolkit-catalog"),
+  respondToolConfirmation: (payload = {}) =>
+    ipcRenderer.invoke("miso:tool-confirmation", payload),
   pickWorkspaceRoot: (defaultPath = "") =>
     ipcRenderer.invoke("miso:pick-workspace-root", { defaultPath }),
   validateWorkspaceRoot: (path = "") =>

--- a/src/COMPONENTs/chat-bubble/chat_bubble.js
+++ b/src/COMPONENTs/chat-bubble/chat_bubble.js
@@ -11,6 +11,8 @@ const ChatBubble = ({
   onDeleteMessage,
   onResendMessage,
   onEditMessage,
+  onToolConfirmationDecision,
+  toolConfirmationUiStateById = {},
   disableActionButtons = false,
   traceFrames = [],
 }) => {
@@ -86,6 +88,8 @@ const ChatBubble = ({
         <TraceChain
           frames={traceFrames}
           status={message.status}
+          onToolConfirmationDecision={onToolConfirmationDecision}
+          toolConfirmationUiStateById={toolConfirmationUiStateById}
           streamingContent={
             message.status === "streaming" ? message.content : ""
           }
@@ -178,6 +182,10 @@ const areChatBubblePropsEqual = (previousProps, nextProps) =>
   previousProps.onDeleteMessage === nextProps.onDeleteMessage &&
   previousProps.onResendMessage === nextProps.onResendMessage &&
   previousProps.onEditMessage === nextProps.onEditMessage &&
+  previousProps.onToolConfirmationDecision ===
+    nextProps.onToolConfirmationDecision &&
+  previousProps.toolConfirmationUiStateById ===
+    nextProps.toolConfirmationUiStateById &&
   previousProps.disableActionButtons === nextProps.disableActionButtons &&
   previousProps.traceFrames === nextProps.traceFrames;
 

--- a/src/COMPONENTs/chat-bubble/trace_chain.js
+++ b/src/COMPONENTs/chat-bubble/trace_chain.js
@@ -10,6 +10,7 @@ import Icon from "../../BUILTIN_COMPONENTs/icon/icon";
 const DISPLAY_FRAME_TYPES = new Set([
   "reasoning",
   "observation",
+  "tool_confirmation_request",
   "tool_call",
   "tool_result",
   "final_message",
@@ -206,7 +207,13 @@ const ErrorPoint = () => (
 
 /* ─── TraceChain ─────────────────────────────────────────────────────────── */
 
-const TraceChain = ({ frames = [], status, streamingContent = "" }) => {
+const TraceChain = ({
+  frames = [],
+  status,
+  streamingContent = "",
+  onToolConfirmationDecision,
+  toolConfirmationUiStateById = {},
+}) => {
   const { theme, onThemeMode } = useContext(ConfigContext);
   const isDark = onThemeMode === "dark_mode";
   const color = theme?.color || "#222";
@@ -305,6 +312,21 @@ const TraceChain = ({ frames = [], status, streamingContent = "" }) => {
     return m;
   }, [frames]);
 
+  const confirmationStatusByCallId = useMemo(() => {
+    const map = new Map();
+    for (const frame of frames) {
+      if (!frame?.payload?.call_id) {
+        continue;
+      }
+      if (frame.type === "tool_confirmed") {
+        map.set(frame.payload.call_id, "approved");
+      } else if (frame.type === "tool_denied") {
+        map.set(frame.payload.call_id, "denied");
+      }
+    }
+    return map;
+  }, [frames]);
+
   const timelineItems = useMemo(() => {
     const items = [];
     const renderedCallIds = new Set();
@@ -337,6 +359,174 @@ const TraceChain = ({ frames = [], status, streamingContent = "" }) => {
               >
                 {text}
               </Markdown>
+            ) : undefined,
+        });
+      } else if (frame.type === "tool_confirmation_request") {
+        const callId =
+          typeof frame.payload?.call_id === "string" ? frame.payload.call_id : "";
+        const toolName =
+          typeof frame.payload?.tool_name === "string"
+            ? frame.payload.tool_name
+            : "tool";
+        const confirmationId =
+          typeof frame.payload?.confirmation_id === "string"
+            ? frame.payload.confirmation_id
+            : "";
+        const description =
+          typeof frame.payload?.description === "string"
+            ? frame.payload.description.trim()
+            : "";
+        const args = frame.payload?.arguments;
+        const confirmationResult = callId
+          ? confirmationStatusByCallId.get(callId)
+          : "";
+
+        const confirmationUiState =
+          confirmationId && toolConfirmationUiStateById
+            ? toolConfirmationUiStateById[confirmationId] || {}
+            : {};
+        const uiStatus =
+          typeof confirmationUiState?.status === "string"
+            ? confirmationUiState.status
+            : "idle";
+        const uiError =
+          typeof confirmationUiState?.error === "string"
+            ? confirmationUiState.error
+            : "";
+
+        const isResolved =
+          confirmationResult === "approved" || confirmationResult === "denied";
+        const isSubmitting =
+          uiStatus === "submitting" || uiStatus === "submitted";
+
+        let statusLabel = "Pending";
+        if (confirmationResult === "approved") {
+          statusLabel = "Approved";
+        } else if (confirmationResult === "denied") {
+          statusLabel = "Denied";
+        } else if (isSubmitting) {
+          statusLabel = "Submitting...";
+        } else if (uiError) {
+          statusLabel = "Failed to submit";
+        }
+
+        const canTakeAction =
+          !isResolved &&
+          !isSubmitting &&
+          confirmationId &&
+          typeof onToolConfirmationDecision === "function";
+
+        const statusColor = isResolved
+          ? confirmationResult === "approved"
+            ? isDark
+              ? "rgba(110,231,183,0.95)"
+              : "rgba(5,150,105,0.95)"
+            : isDark
+              ? "rgba(252,165,165,0.95)"
+              : "rgba(220,38,38,0.95)"
+          : isDark
+            ? "rgba(255,255,255,0.6)"
+            : "rgba(0,0,0,0.52)";
+
+        const argsPairs = toKVPairs(args);
+        const detailsSections = [];
+        if (description) {
+          detailsSections.push({
+            heading: "description",
+            pairs: [{ key: "text", value: description }],
+          });
+        }
+        if (argsPairs.length) {
+          detailsSections.push({
+            heading: "args",
+            pairs: argsPairs,
+          });
+        }
+        if (uiError) {
+          detailsSections.push({
+            heading: "error",
+            pairs: [{ key: "message", value: uiError }],
+          });
+        }
+
+        const actionButtonBaseStyle = {
+          border: "none",
+          borderRadius: 6,
+          padding: "4px 10px",
+          cursor: "pointer",
+          fontSize: 11.5,
+          lineHeight: 1.4,
+          fontFamily: "Menlo, Monaco, Consolas, monospace",
+        };
+
+        items.push({
+          key: `${frame.seq}-tool-confirmation`,
+          title: "Tool Confirmation",
+          span: spanText,
+          status: isResolved ? "done" : "active",
+          point: isResolved ? <HammerPoint isDark={isDark} /> : "loading",
+          body: (
+            <div
+              style={{
+                display: "flex",
+                alignItems: "center",
+                gap: 8,
+                flexWrap: "wrap",
+              }}
+            >
+              <ToolTag name={toolName} isDark={isDark} />
+              <span
+                style={{
+                  fontSize: 11.5,
+                  color: statusColor,
+                  fontFamily: "Menlo, Monaco, Consolas, monospace",
+                }}
+              >
+                {statusLabel}
+              </span>
+              {canTakeAction && (
+                <>
+                  <button
+                    onClick={() =>
+                      onToolConfirmationDecision({
+                        confirmationId,
+                        approved: true,
+                      })
+                    }
+                    style={{
+                      ...actionButtonBaseStyle,
+                      color: isDark ? "rgba(209,250,229,0.95)" : "#065f46",
+                      backgroundColor: isDark
+                        ? "rgba(16,185,129,0.22)"
+                        : "rgba(16,185,129,0.16)",
+                    }}
+                  >
+                    Allow
+                  </button>
+                  <button
+                    onClick={() =>
+                      onToolConfirmationDecision({
+                        confirmationId,
+                        approved: false,
+                      })
+                    }
+                    style={{
+                      ...actionButtonBaseStyle,
+                      color: isDark ? "rgba(254,202,202,0.98)" : "#991b1b",
+                      backgroundColor: isDark
+                        ? "rgba(239,68,68,0.2)"
+                        : "rgba(239,68,68,0.14)",
+                    }}
+                  >
+                    Deny
+                  </button>
+                </>
+              )}
+            </div>
+          ),
+          details:
+            detailsSections.length > 0 ? (
+              <KVPanel sections={detailsSections} isDark={isDark} color={color} />
             ) : undefined,
         });
       } else if (frame.type === "tool_call") {
@@ -461,6 +651,9 @@ const TraceChain = ({ frames = [], status, streamingContent = "" }) => {
     streamingContent,
     startFrame,
     toolResultByCallId,
+    confirmationStatusByCallId,
+    onToolConfirmationDecision,
+    toolConfirmationUiStateById,
     isDark,
     color,
   ]);

--- a/src/COMPONENTs/chat-bubble/trace_chain.test.js
+++ b/src/COMPONENTs/chat-bubble/trace_chain.test.js
@@ -1,11 +1,16 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ConfigContext } from "../../CONTAINERs/config/context";
 import TraceChain from "./trace_chain";
 
 jest.mock("../../BUILTIN_COMPONENTs/icon/icon", () => () => null);
 
-const renderTraceChain = ({ frames, status = "done" }) =>
+const renderTraceChain = ({
+  frames,
+  status = "done",
+  onToolConfirmationDecision = null,
+  toolConfirmationUiStateById = {},
+}) =>
   render(
     <ConfigContext.Provider
       value={{
@@ -13,7 +18,12 @@ const renderTraceChain = ({ frames, status = "done" }) =>
         onThemeMode: "light_mode",
       }}
     >
-      <TraceChain frames={frames} status={status} />
+      <TraceChain
+        frames={frames}
+        status={status}
+        onToolConfirmationDecision={onToolConfirmationDecision}
+        toolConfirmationUiStateById={toolConfirmationUiStateById}
+      />
     </ConfigContext.Provider>,
   );
 
@@ -53,7 +63,7 @@ describe("TraceChain final_message draft timeline", () => {
 
     renderTraceChain({ frames, status: "done" });
 
-    expect(screen.getAllByText("Assistant Draft")).toHaveLength(1);
+    expect(screen.getAllByText("Response").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("intermediate draft content")).toBeInTheDocument();
     expect(screen.queryByText("final answer content")).not.toBeInTheDocument();
   });
@@ -138,13 +148,13 @@ describe("TraceChain final_message draft timeline", () => {
     expect(screen.getByText("Reasoning")).toBeInTheDocument();
     expect(screen.getByText("read_file")).toBeInTheDocument();
     expect(screen.getByText("Error")).toBeInTheDocument();
-    expect(screen.getByText("Assistant Draft")).toBeInTheDocument();
+    expect(screen.getByText("Response")).toBeInTheDocument();
 
     const timelineText = container.textContent || "";
     expect(timelineText.indexOf("Reasoning")).toBeLessThan(
-      timelineText.indexOf("Assistant Draft"),
+      timelineText.indexOf("Response"),
     );
-    expect(timelineText.indexOf("Assistant Draft")).toBeLessThan(
+    expect(timelineText.indexOf("Response")).toBeLessThan(
       timelineText.indexOf("Error"),
     );
   });
@@ -171,11 +181,80 @@ describe("TraceChain final_message draft timeline", () => {
 
     renderTraceChain({ frames, status: "streaming" });
 
-    expect(screen.getAllByText("Assistant Draft")).toHaveLength(1);
+    expect(screen.getAllByText("Response").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("older draft")).toBeInTheDocument();
-    expect(
-      screen.queryByText("latest in-progress answer"),
-    ).not.toBeInTheDocument();
+    expect(screen.getByText("latest in-progress answer")).toBeInTheDocument();
     expect(screen.getAllByText("Thinking…").length).toBeGreaterThan(0);
+  });
+
+  test("renders tool confirmation actions and forwards allow decision", () => {
+    const onToolConfirmationDecision = jest.fn();
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({
+        seq: 2,
+        type: "tool_confirmation_request",
+        payload: {
+          call_id: "call-1",
+          confirmation_id: "confirm-1",
+          tool_name: "delete_file",
+          arguments: { path: "demo.txt" },
+        },
+      }),
+    ];
+
+    renderTraceChain({
+      frames,
+      status: "streaming",
+      onToolConfirmationDecision,
+      toolConfirmationUiStateById: {
+        "confirm-1": { status: "idle", error: "" },
+      },
+    });
+
+    const allowButton = screen.getByRole("button", { name: "Allow" });
+    fireEvent.click(allowButton);
+    expect(onToolConfirmationDecision).toHaveBeenCalledWith({
+      confirmationId: "confirm-1",
+      approved: true,
+    });
+    expect(screen.getByRole("button", { name: "Deny" })).toBeInTheDocument();
+  });
+
+  test("hides tool confirmation actions after confirmation is resolved", () => {
+    const frames = [
+      frame({ seq: 1, type: "stream_started", payload: {} }),
+      frame({
+        seq: 2,
+        type: "tool_confirmation_request",
+        payload: {
+          call_id: "call-1",
+          confirmation_id: "confirm-1",
+          tool_name: "delete_file",
+          arguments: { path: "demo.txt" },
+        },
+      }),
+      frame({
+        seq: 3,
+        type: "tool_confirmed",
+        payload: {
+          call_id: "call-1",
+          tool_name: "delete_file",
+        },
+      }),
+    ];
+
+    renderTraceChain({
+      frames,
+      status: "done",
+      onToolConfirmationDecision: jest.fn(),
+      toolConfirmationUiStateById: {
+        "confirm-1": { status: "submitted", error: "" },
+      },
+    });
+
+    expect(screen.queryByRole("button", { name: "Allow" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Deny" })).not.toBeInTheDocument();
+    expect(screen.getByText("Approved")).toBeInTheDocument();
   });
 });

--- a/src/COMPONENTs/chat-messages/chat_messages.js
+++ b/src/COMPONENTs/chat-messages/chat_messages.js
@@ -11,6 +11,8 @@ const ChatMessages = ({
   onDeleteMessage,
   onResendMessage,
   onEditMessage,
+  onToolConfirmationDecision,
+  toolConfirmationUiStateById = {},
   className = "scrollable",
   initialVisibleCount = 12,
   loadBatchSize = 6,
@@ -97,6 +99,8 @@ const ChatMessages = ({
                   onDeleteMessage={onDeleteMessage}
                   onResendMessage={onResendMessage}
                   onEditMessage={onEditMessage}
+                  onToolConfirmationDecision={onToolConfirmationDecision}
+                  toolConfirmationUiStateById={toolConfirmationUiStateById}
                   disableActionButtons={isStreaming}
                   traceFrames={
                     Array.isArray(msg.traceFrames) ? msg.traceFrames : []

--- a/src/PAGEs/chat/chat.js
+++ b/src/PAGEs/chat/chat.js
@@ -202,7 +202,10 @@ const ChatInterface = () => {
   );
   const [selectedModelId, setSelectedModelId] = useState(modelIdRef.current);
   const [selectedToolkits, setSelectedToolkits] = useState([]);
+  const [toolConfirmationUiStateById, setToolConfirmationUiStateById] =
+    useState({});
   const selectedToolkitsRef = useRef([]);
+  const confirmationIdByCallIdRef = useRef(new Map());
   useEffect(() => {
     selectedToolkitsRef.current = selectedToolkits;
   }, [selectedToolkits]);
@@ -438,6 +441,7 @@ const ChatInterface = () => {
       streamingChatIdRef.current = null;
       activeStreamMessagesRef.current = null;
       attachmentPayloadByChat.clear();
+      confirmationIdByCallIdRef.current.clear();
       cleanupTransientNewChatOnPageLeave({ source: "chat-page" });
     };
   }, []);
@@ -519,6 +523,8 @@ const ChatInterface = () => {
     streamingChatIdRef.current = null;
     activeStreamMessagesRef.current = null;
     setStreamingChatId(null);
+    confirmationIdByCallIdRef.current.clear();
+    setToolConfirmationUiStateById({});
     // Remove empty assistant placeholder; mark partial ones as cancelled
     setMessages((prev) => {
       const { changed, nextMessages } = settleStreamingAssistantMessages(prev);
@@ -530,6 +536,110 @@ const ChatInterface = () => {
       return nextMessages;
     });
   }, []);
+
+  const clearResolvedToolConfirmationByCallId = useCallback((callId) => {
+    if (typeof callId !== "string" || !callId.trim()) {
+      return;
+    }
+    const confirmationId = confirmationIdByCallIdRef.current.get(callId);
+    if (!confirmationId) {
+      return;
+    }
+
+    confirmationIdByCallIdRef.current.delete(callId);
+    setToolConfirmationUiStateById((previous) => {
+      if (!previous || !previous[confirmationId]) {
+        return previous;
+      }
+      const next = { ...previous };
+      delete next[confirmationId];
+      return next;
+    });
+  }, []);
+
+  const clearAllPendingToolConfirmations = useCallback(() => {
+    const activeConfirmationIds = [
+      ...new Set(confirmationIdByCallIdRef.current.values()),
+    ];
+    confirmationIdByCallIdRef.current.clear();
+    if (activeConfirmationIds.length === 0) {
+      return;
+    }
+
+    setToolConfirmationUiStateById((previous) => {
+      const next = { ...previous };
+      let changed = false;
+      activeConfirmationIds.forEach((confirmationId) => {
+        if (confirmationId && next[confirmationId]) {
+          delete next[confirmationId];
+          changed = true;
+        }
+      });
+      return changed ? next : previous;
+    });
+  }, []);
+
+  const handleToolConfirmationDecision = useCallback(
+    async ({ confirmationId, approved }) => {
+      const normalizedConfirmationId =
+        typeof confirmationId === "string" ? confirmationId.trim() : "";
+      if (!normalizedConfirmationId) {
+        return;
+      }
+
+      let shouldSubmit = false;
+      setToolConfirmationUiStateById((previous) => {
+        const current = previous[normalizedConfirmationId] || {};
+        if (
+          current.status === "submitting" ||
+          current.status === "submitted"
+        ) {
+          return previous;
+        }
+        shouldSubmit = true;
+        return {
+          ...previous,
+          [normalizedConfirmationId]: {
+            status: "submitting",
+            error: "",
+          },
+        };
+      });
+
+      if (!shouldSubmit) {
+        return;
+      }
+
+      try {
+        await api.miso.respondToolConfirmation({
+          confirmation_id: normalizedConfirmationId,
+          approved: Boolean(approved),
+          reason: "",
+        });
+        setToolConfirmationUiStateById((previous) => ({
+          ...previous,
+          [normalizedConfirmationId]: {
+            ...(previous[normalizedConfirmationId] || {}),
+            status: "submitted",
+            error: "",
+          },
+        }));
+      } catch (error) {
+        const errorMessage =
+          (typeof error?.message === "string" && error.message) ||
+          "Failed to submit confirmation";
+        setToolConfirmationUiStateById((previous) => ({
+          ...previous,
+          [normalizedConfirmationId]: {
+            ...(previous[normalizedConfirmationId] || {}),
+            status: "error",
+            error: errorMessage,
+          },
+        }));
+      }
+    },
+    [],
+  );
 
   const getOrCreateChatAttachmentPayloadMap = useCallback((chatId) => {
     if (!chatId) {
@@ -734,6 +844,9 @@ const ChatInterface = () => {
           ? reuseUserMessage
           : null;
 
+      confirmationIdByCallIdRef.current.clear();
+      setToolConfirmationUiStateById({});
+
       const assistantMessageId = `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
       const timestamp = Date.now();
 
@@ -874,6 +987,40 @@ const ChatInterface = () => {
             onFrame: (frame) => {
               if (!frame || frame.type === "token_delta") return;
               const patchTime = Date.now();
+
+              if (frame.type === "tool_confirmation_request") {
+                const callId =
+                  typeof frame.payload?.call_id === "string"
+                    ? frame.payload.call_id
+                    : "";
+                const confirmationId =
+                  typeof frame.payload?.confirmation_id === "string"
+                    ? frame.payload.confirmation_id
+                    : "";
+                if (callId && confirmationId) {
+                  confirmationIdByCallIdRef.current.set(callId, confirmationId);
+                  setToolConfirmationUiStateById((previous) =>
+                    previous[confirmationId]
+                      ? previous
+                      : {
+                          ...previous,
+                          [confirmationId]: {
+                            status: "idle",
+                            error: "",
+                          },
+                        },
+                  );
+                }
+              } else if (
+                frame.type === "tool_confirmed" ||
+                frame.type === "tool_denied"
+              ) {
+                const callId =
+                  typeof frame.payload?.call_id === "string"
+                    ? frame.payload.call_id
+                    : "";
+                clearResolvedToolConfirmationByCallId(callId);
+              }
 
               // final_message carries the complete reply text
               if (frame.type === "final_message") {
@@ -1052,6 +1199,7 @@ const ChatInterface = () => {
               streamingChatIdRef.current = null;
               activeStreamMessagesRef.current = null;
               setStreamingChatId(null);
+              clearAllPendingToolConfirmations();
               if (activeChatIdRef.current !== chatId) {
                 setChatGeneratedUnread(chatId, true, {
                   source: "chat-page",
@@ -1074,6 +1222,7 @@ const ChatInterface = () => {
               streamHandleRef.current = null;
               streamingChatIdRef.current = null;
               setStreamingChatId(null);
+              clearAllPendingToolConfirmations();
 
               const nextStreamMessages = streamMessages.map((message) => {
                 if (message.id !== assistantMessageId) {
@@ -1161,6 +1310,8 @@ const ChatInterface = () => {
     },
     [
       buildHistoryForModel,
+      clearAllPendingToolConfirmations,
+      clearResolvedToolConfirmationByCallId,
       getOrCreateChatAttachmentPayloadMap,
       resolveAttachmentPayloads,
     ],
@@ -1936,6 +2087,8 @@ const ChatInterface = () => {
             onDeleteMessage={handleDeleteMessage}
             onResendMessage={handleResendMessage}
             onEditMessage={handleEditMessage}
+            onToolConfirmationDecision={handleToolConfirmationDecision}
+            toolConfirmationUiStateById={toolConfirmationUiStateById}
             initialVisibleCount={12}
             loadBatchSize={6}
             topLoadThreshold={80}

--- a/src/SERVICEs/api.js
+++ b/src/SERVICEs/api.js
@@ -561,6 +561,57 @@ export const api = {
       }
     },
 
+    respondToolConfirmation: async (payload = {}) => {
+      try {
+        const method = assertBridgeMethod("misoAPI", "respondToolConfirmation");
+        const confirmationIdRaw = payload?.confirmation_id;
+        const confirmationId =
+          typeof confirmationIdRaw === "string" ? confirmationIdRaw.trim() : "";
+        if (!confirmationId) {
+          throw new FrontendApiError(
+            "invalid_confirmation_request",
+            "confirmation_id is required",
+          );
+        }
+
+        const reasonRaw = payload?.reason;
+        const requestPayload = {
+          confirmation_id: confirmationId,
+          approved: Boolean(payload?.approved),
+          reason:
+            typeof reasonRaw === "string"
+              ? reasonRaw
+              : String(reasonRaw || ""),
+        };
+
+        const modifiedArguments = payload?.modified_arguments;
+        if (modifiedArguments != null) {
+          if (!isObject(modifiedArguments)) {
+            throw new FrontendApiError(
+              "invalid_confirmation_request",
+              "modified_arguments must be an object when provided",
+            );
+          }
+          requestPayload.modified_arguments = modifiedArguments;
+        }
+
+        const response = await withTimeout(
+          () => method(requestPayload),
+          10000,
+          "miso_tool_confirmation_timeout",
+          "Tool confirmation request timed out",
+        );
+
+        return isObject(response) ? response : { status: "ok" };
+      } catch (error) {
+        throw toFrontendApiError(
+          error,
+          "miso_tool_confirmation_failed",
+          "Failed to submit tool confirmation",
+        );
+      }
+    },
+
     retrieveModelList: retrieveMisoModelList,
     listModels: retrieveMisoModelList,
 


### PR DESCRIPTION
- Implemented a new endpoint for tool confirmation in routes.py.
- Added validation for confirmation requests, including required fields and argument types.
- Integrated tool confirmation handling in the chat interface, allowing users to approve or deny tool actions.
- Enhanced the chat bubble and trace chain components to display tool confirmation requests and their statuses.
- Updated API service to handle tool confirmation responses and errors.
- Added unit tests for tool confirmation logic and integration tests for the new endpoint.