### PR TITLE
Issue120: no error message when api key available

### DIFF
--- a/src/COMPONENTs/chat-bubble/components/assistant_message_body.js
+++ b/src/COMPONENTs/chat-bubble/components/assistant_message_body.js
@@ -1,4 +1,5 @@
-import { memo } from "react";
+import { memo, useContext } from "react";
+import { ConfigContext } from "../../../CONTAINERs/config/context";
 import CellSplitSpinner from "../../../BUILTIN_COMPONENTs/spinner/cell_split_spinner";
 import SeamlessMarkdown from "./seamless_markdown";
 import {
@@ -12,6 +13,51 @@ const AssistantMessageBody = ({
   theme,
   hasTraceFrames = false,
 }) => {
+  const { onThemeMode } = useContext(ConfigContext);
+  const isDark = onThemeMode === "dark_mode";
+
+  if (message.status === "error") {
+    const errorMsg =
+      message.meta?.error?.message ||
+      (typeof message.content === "string"
+        ? message.content.replace(/^\[error\]\s*/i, "")
+        : "An error occurred");
+    return (
+      <div
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          gap: 8,
+          padding: "6px 10px",
+          borderRadius: 8,
+          backgroundColor: isDark ? "rgba(239,68,68,0.12)" : "rgba(239,68,68,0.08)",
+          border: `1px solid ${isDark ? "rgba(239,68,68,0.3)" : "rgba(239,68,68,0.25)"}`,
+          marginTop: 2,
+        }}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          width="15"
+          height="15"
+          style={{ color: isDark ? "#f87171" : "#dc2626", flexShrink: 0, marginTop: 2 }}
+        >
+          <path d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM11 15V17H13V15H11ZM11 7V13H13V7H11Z" />
+        </svg>
+        <span
+          style={{
+            color: isDark ? "#f87171" : "#dc2626",
+            fontSize: ASSISTANT_MARKDOWN_FONT_SIZE,
+            lineHeight: ASSISTANT_MARKDOWN_LINE_HEIGHT,
+          }}
+        >
+          {errorMsg}
+        </span>
+      </div>
+    );
+  }
+
   // When timeline is already visible (has trace frames), skip the spinner —
   // the TraceChain "Thinking…" indicator is enough.
   if (message.status === "streaming" && !message.content) {

--- a/unchain_runtime/server/route_chat.py
+++ b/unchain_runtime/server/route_chat.py
@@ -73,6 +73,23 @@ def _sanitize_trace_value(value: object, trace_level: str, depth: int = 0):
     return value
 
 
+def _is_invalid_api_key_error(exc: Exception) -> bool:
+    if "Authentication" in type(exc).__name__:
+        return True
+    lower = str(exc).lower()
+    return any(
+        p in lower
+        for p in (
+            "invalid api key",
+            "incorrect api key",
+            "invalid_api_key",
+            "incorrect_api_key",
+            "authentication_error",
+            "invalid x-api-key",
+        )
+    )
+
+
 def _normalize_stream_error(stream_error: Exception) -> tuple[str, str]:
     message = str(stream_error)
     code = "stream_failed"
@@ -84,6 +101,9 @@ def _normalize_stream_error(stream_error: Exception) -> tuple[str, str]:
                 tail = normalized.split(":", 1)[1].strip()
                 if tail:
                     message = tail
+        elif _is_invalid_api_key_error(stream_error):
+            code = "invalid_api_key"
+            message = "API key is invalid or has been revoked. Please update your API key in Settings."
     return code, message
 
 


### PR DESCRIPTION
https://github.com/haoxiang-xu/PuPu/issues/120

Detect invalid API key errors in the streaming pipeline and surface them as a styled inline error card in the chat bubble, replacing the raw provider exception message with a clear, actionable prompt to update settings.
See in screenshots.
<img width="924" height="784" alt="image" src="https://github.com/user-attachments/assets/bed0081d-857d-46e1-859e-48a7f7ae73f1" />
<img width="796" height="592" alt="image" src="https://github.com/user-attachments/assets/e87183e7-ad99-497c-a262-2d99d8a64762" />
