### PR TITLE
Integrate durable Unchain session semantics

### DIFF
--- a/unchain_runtime/server/memory_embeddings.py
+++ b/unchain_runtime/server/memory_embeddings.py
@@ -96,12 +96,8 @@ def _prepare_vector_collection_tag(
     if not session_id:
         return ""
 
-    try:
-        state = store.load(session_id)
-    except Exception:
-        state = {}
-    if not isinstance(state, dict):
-        state = {}
+    session_snapshot = root._load_session_snapshot_compat(store, session_id)
+    state = dict(session_snapshot.state)
 
     previous_signature = str(state.get("vector_embedding_signature", "") or "").strip()
     previous_tag = str(state.get("vector_collection_tag", "") or "").strip()
@@ -115,17 +111,33 @@ def _prepare_vector_collection_tag(
     if previous_signature and previous_signature != embedding_signature:
         existing_messages = root._deepcopy_messages(state.get("messages"))
         state["vector_indexed_until"] = len(existing_messages)
-        if previous_tag:
-            old_collection = _session_collection_name(
-                session_id=session_id,
-                collection_prefix=_vector_collection_prefix(previous_tag),
-            )
-            root._delete_collection_best_effort(client, old_collection)
-
     try:
-        store.save(session_id, state)
-    except Exception:
-        pass
+        root._save_session_snapshot_compat(
+            store,
+            session_id,
+            state,
+            expected_revision=session_snapshot.revision,
+        )
+    except Exception as exc:
+        if str(getattr(exc, "code", "") or "") != "session_revision_conflict":
+            raise
+        winner_snapshot = root._load_session_snapshot_compat(store, session_id)
+        winner_state = dict(winner_snapshot.state)
+        winner_signature = str(
+            winner_state.get("vector_embedding_signature", "") or ""
+        ).strip()
+        raw_winner_tag = winner_state.get("vector_collection_tag")
+        winner_tag = raw_winner_tag.strip() if isinstance(raw_winner_tag, str) else ""
+        if winner_signature == embedding_signature and winner_tag:
+            return winner_tag
+        raise
+
+    if previous_signature and previous_signature != embedding_signature and previous_tag:
+        old_collection = _session_collection_name(
+            session_id=session_id,
+            collection_prefix=_vector_collection_prefix(previous_tag),
+        )
+        root._delete_collection_best_effort(client, old_collection)
 
     return new_tag
 

--- a/unchain_runtime/server/memory_factory.py
+++ b/unchain_runtime/server/memory_factory.py
@@ -42,6 +42,46 @@ _qdrant_clients_lock = threading.Lock()
 # Internal helpers
 # ---------------------------------------------------------------------------
 
+def _load_session_snapshot_compat(store: Any, session_id: str):
+    try:
+        from unchain.memory import load_session_snapshot
+    except ImportError:
+        state = store.load(session_id)
+        if not isinstance(state, dict):
+            raise TypeError("session store must return a dict")
+        return SimpleNamespace(
+            state=copy.deepcopy(state),
+            revision=None,
+            revision_supported=False,
+            consistency="best_effort",
+        )
+    return load_session_snapshot(store, session_id)
+
+
+def _save_session_snapshot_compat(
+    store: Any,
+    session_id: str,
+    state: dict[str, Any],
+    *,
+    expected_revision: int | None,
+):
+    try:
+        from unchain.memory import save_session_snapshot
+    except ImportError:
+        store.save(session_id, copy.deepcopy(state))
+        return SimpleNamespace(
+            state=copy.deepcopy(state),
+            revision=None,
+            revision_supported=False,
+            consistency="best_effort",
+        )
+    return save_session_snapshot(
+        store,
+        session_id,
+        state,
+        expected_revision=expected_revision,
+    )
+
 def _data_dir() -> str:
     return os.environ.get("UNCHAIN_DATA_DIR", "").strip()
 
@@ -1029,8 +1069,22 @@ def _patch_memory_commit_with_overlap(manager: Any) -> Any:
         memory_namespace: str | None = None,
         model: str | None = None,
         long_term_extractor: Callable[..., Any] | None = None,
-    ) -> None:
-        existing_state = self.store.load(session_id) if session_id else {}
+        expected_revision: int | None = None,
+        summary_text: str | None = None,
+        return_result: bool = False,
+        clear_execution_checkpoint_id: str | None = None,
+    ):
+        store_snapshot = None
+        if session_id:
+            try:
+                from unchain.memory import load_session_snapshot
+
+                store_snapshot = load_session_snapshot(self.store, session_id)
+                existing_state = store_snapshot.state
+            except ImportError:
+                existing_state = self.store.load(session_id)
+        else:
+            existing_state = {}
         existing_messages = (
             existing_state.get("messages", [])
             if isinstance(existing_state, dict)
@@ -1050,6 +1104,20 @@ def _patch_memory_commit_with_overlap(manager: Any) -> Any:
             commit_kwargs["model"] = model
         if "long_term_extractor" in commit_params:
             commit_kwargs["long_term_extractor"] = long_term_extractor
+        if "expected_revision" in commit_params:
+            commit_kwargs["expected_revision"] = (
+                expected_revision
+                if expected_revision is not None
+                else getattr(store_snapshot, "revision", None)
+            )
+        if "summary_text" in commit_params:
+            commit_kwargs["summary_text"] = summary_text
+        if "return_result" in commit_params:
+            commit_kwargs["return_result"] = return_result
+        if "clear_execution_checkpoint_id" in commit_params:
+            commit_kwargs["clear_execution_checkpoint_id"] = (
+                clear_execution_checkpoint_id
+            )
         return original_commit(**commit_kwargs)
 
     setattr(manager, "commit_messages", MethodType(_patched_commit_messages, manager))
@@ -1084,25 +1152,6 @@ def _patch_memory_prepare_with_diagnostics(manager: Any) -> Any:
         supports_tools: bool | None = None,
     ) -> list[dict[str, Any]]:
         clean_incoming = _sanitize_dialog_messages(incoming)
-
-        store = getattr(self, "store", None)
-        if (
-            session_id
-            and store is not None
-            and callable(getattr(store, "load", None))
-            and callable(getattr(store, "save", None))
-        ):
-            try:
-                state = store.load(session_id)
-                if isinstance(state, dict):
-                    existing_messages = state.get("messages")
-                    clean_existing_messages = _sanitize_dialog_messages(existing_messages)
-                    if clean_existing_messages != _deepcopy_messages(existing_messages):
-                        next_state = dict(state)
-                        next_state["messages"] = clean_existing_messages
-                        store.save(session_id, next_state)
-            except Exception:
-                pass
 
         prepare_kwargs = {
             "session_id": session_id,
@@ -1379,12 +1428,8 @@ def replace_short_term_session_memory(
     raw_options = options if isinstance(options, dict) else {}
     retained_messages = _sanitize_dialog_messages(messages)
 
-    try:
-        previous_state = store.load(normalized_session_id)
-    except Exception:
-        previous_state = {}
-    if not isinstance(previous_state, dict):
-        previous_state = {}
+    previous_snapshot = _load_session_snapshot_compat(store, normalized_session_id)
+    previous_state = previous_snapshot.state
 
     old_tag = str(previous_state.get("vector_collection_tag", "") or "").strip()
     old_collection_name = _session_collection_name(
@@ -1452,10 +1497,23 @@ def replace_short_term_session_memory(
     next_state = dict(previous_state)
     next_state["messages"] = retained_messages
     next_state.pop("summary", None)
+    checkpoint_cleared = next_state.pop("execution_checkpoint", None) is not None
     next_state["vector_indexed_until"] = vector_indexed_until
     next_state["vector_collection_tag"] = new_tag
     next_state["vector_embedding_signature"] = vector_signature
-    store.save(normalized_session_id, next_state)
+    try:
+        persisted_snapshot = _save_session_snapshot_compat(
+            store,
+            normalized_session_id,
+            next_state,
+            expected_revision=previous_snapshot.revision,
+        )
+    except Exception as exc:
+        if getattr(exc, "code", "") != "session_revision_conflict":
+            raise
+        if qdrant_client is not None:
+            _delete_collection_best_effort(qdrant_client, new_collection_name)
+        raise
 
     if qdrant_client is None and _QDRANT_AVAILABLE:
         try:
@@ -1478,6 +1536,10 @@ def replace_short_term_session_memory(
         "vector_indexed_until": vector_indexed_until,
         "vector_fallback_reason": vector_fallback_reason,
     }
+    if checkpoint_cleared:
+        response["execution_checkpoint_cleared"] = True
+    if isinstance(persisted_snapshot.revision, int):
+        response["session_revision"] = persisted_snapshot.revision
     if cleanup_warning:
         response["cleanup_warning"] = cleanup_warning
     return response

--- a/unchain_runtime/server/route_memory.py
+++ b/unchain_runtime/server/route_memory.py
@@ -39,6 +39,17 @@ def replace_memory_session() -> Response:
     except ValueError as exc:
         return root._json_error("invalid_request", str(exc), 400)
     except Exception as exc:
+        if getattr(exc, "code", "") == "session_revision_conflict":
+            return jsonify(
+                {
+                    "error": {
+                        "code": "session_revision_conflict",
+                        "message": str(exc),
+                        "expected_revision": getattr(exc, "expected_revision", None),
+                        "actual_revision": getattr(exc, "actual_revision", None),
+                    }
+                }
+            ), 409
         return jsonify(
             {
                 "error": {

--- a/unchain_runtime/server/tests/test_memory_factory.py
+++ b/unchain_runtime/server/tests/test_memory_factory.py
@@ -674,6 +674,91 @@ class MemoryFactoryTests(unittest.TestCase):
         )
         self.assertEqual(delete_calls["collections"], [])
 
+    def test_prepare_vector_collection_tag_adopts_matching_cas_winner(self) -> None:
+        class RevisionConflict(RuntimeError):
+            code = "session_revision_conflict"
+
+        initial_snapshot = types.SimpleNamespace(
+            state={
+                "messages": [{"role": "user", "content": "hello"}],
+                "vector_embedding_signature": "old:model:10",
+                "vector_collection_tag": "oldtag",
+            },
+            revision=4,
+        )
+        winner_snapshot = types.SimpleNamespace(
+            state={
+                "messages": [{"role": "user", "content": "hello"}],
+                "vector_embedding_signature": "new:model:20",
+                "vector_collection_tag": "winnertag",
+            },
+            revision=5,
+        )
+
+        with mock.patch.object(
+            memory_factory,
+            "_load_session_snapshot_compat",
+            side_effect=[initial_snapshot, winner_snapshot],
+        ) as load_snapshot, mock.patch.object(
+            memory_factory,
+            "_save_session_snapshot_compat",
+            side_effect=RevisionConflict("lost CAS race"),
+        ), mock.patch.object(
+            memory_factory,
+            "_delete_collection_best_effort",
+        ) as delete_collection:
+            tag = memory_factory._prepare_vector_collection_tag(
+                store=object(),
+                client=object(),
+                session_id="chat-1",
+                embedding_signature="new:model:20",
+            )
+
+        self.assertEqual(tag, "winnertag")
+        self.assertEqual(load_snapshot.call_count, 2)
+        delete_collection.assert_not_called()
+
+    def test_prepare_vector_collection_tag_rejects_different_cas_winner(self) -> None:
+        class RevisionConflict(RuntimeError):
+            code = "session_revision_conflict"
+
+        initial_snapshot = types.SimpleNamespace(
+            state={
+                "vector_embedding_signature": "old:model:10",
+                "vector_collection_tag": "oldtag",
+            },
+            revision=4,
+        )
+        winner_snapshot = types.SimpleNamespace(
+            state={
+                "vector_embedding_signature": "other:model:30",
+                "vector_collection_tag": "othertag",
+            },
+            revision=5,
+        )
+
+        with mock.patch.object(
+            memory_factory,
+            "_load_session_snapshot_compat",
+            side_effect=[initial_snapshot, winner_snapshot],
+        ), mock.patch.object(
+            memory_factory,
+            "_save_session_snapshot_compat",
+            side_effect=RevisionConflict("lost CAS race"),
+        ), mock.patch.object(
+            memory_factory,
+            "_delete_collection_best_effort",
+        ) as delete_collection:
+            with self.assertRaisesRegex(RevisionConflict, "lost CAS race"):
+                memory_factory._prepare_vector_collection_tag(
+                    store=object(),
+                    client=object(),
+                    session_id="chat-1",
+                    embedding_signature="new:model:20",
+                )
+
+        delete_collection.assert_not_called()
+
     def test_replace_short_term_session_memory_rebuilds_vectors(self) -> None:
         previous_state = {
             "chat-1": {
@@ -936,6 +1021,39 @@ class MemoryFactoryTests(unittest.TestCase):
         )
         self.assertEqual(delete_calls["collections"], [])
 
+    def test_replace_short_term_session_memory_clears_checkpoint_with_cas(self) -> None:
+        from unchain.memory import JsonFileSessionStore
+
+        with tempfile.TemporaryDirectory() as data_dir, \
+            mock.patch.dict(os.environ, {"UNCHAIN_DATA_DIR": data_dir}, clear=False), \
+            mock.patch.object(memory_factory, "_QDRANT_AVAILABLE", False):
+            store = JsonFileSessionStore(
+                base_dir=memory_factory._sessions_dir(data_dir)
+            )
+            store.save(
+                "chat-1",
+                {
+                    "messages": [{"role": "user", "content": "old"}],
+                    "execution_checkpoint": {"checkpoint_id": "stale"},
+                },
+            )
+
+            result = memory_factory.replace_short_term_session_memory(
+                session_id="chat-1",
+                messages=[{"role": "user", "content": "replacement"}],
+                options={},
+            )
+            persisted = store.load_with_revision("chat-1")
+
+        self.assertTrue(result["execution_checkpoint_cleared"])
+        self.assertEqual(result["session_revision"], 2)
+        self.assertEqual(persisted.revision, 2)
+        self.assertNotIn("execution_checkpoint", persisted.state)
+        self.assertEqual(
+            persisted.state["messages"],
+            [{"role": "user", "content": "replacement"}],
+        )
+
     def test_merge_messages_with_overlap_appends_only_new_tail(self) -> None:
         existing_messages = [
             {"role": "system", "content": "rules-v1"},
@@ -1113,6 +1231,61 @@ class MemoryFactoryTests(unittest.TestCase):
             },
         )
 
+    def test_patch_memory_commit_forwards_session_revision_and_summary(self) -> None:
+        from unchain.memory import InMemorySessionStore
+
+        class FakeManager:
+            def __init__(self):
+                self.store = InMemorySessionStore()
+                self.store.save(
+                    "chat-test",
+                    {"messages": [{"role": "user", "content": "old"}]},
+                )
+                self.committed_payload = None
+
+            def commit_messages(
+                self,
+                *,
+                session_id: str,
+                full_conversation,
+                expected_revision=None,
+                summary_text=None,
+                clear_execution_checkpoint_id=None,
+            ):
+                self.committed_payload = {
+                    "session_id": session_id,
+                    "full_conversation": full_conversation,
+                    "expected_revision": expected_revision,
+                    "summary_text": summary_text,
+                    "clear_execution_checkpoint_id": clear_execution_checkpoint_id,
+                }
+                return "committed"
+
+        manager = FakeManager()
+        memory_factory._patch_memory_commit_with_overlap(manager)
+
+        result = manager.commit_messages(
+            session_id="chat-test",
+            full_conversation=[{"role": "assistant", "content": "new"}],
+            summary_text="summary",
+            clear_execution_checkpoint_id="checkpoint-1",
+        )
+
+        self.assertEqual(result, "committed")
+        self.assertEqual(manager.committed_payload["expected_revision"], 1)
+        self.assertEqual(manager.committed_payload["summary_text"], "summary")
+        self.assertEqual(
+            manager.committed_payload["clear_execution_checkpoint_id"],
+            "checkpoint-1",
+        )
+        self.assertEqual(
+            manager.committed_payload["full_conversation"],
+            [
+                {"role": "user", "content": "old"},
+                {"role": "assistant", "content": "new"},
+            ],
+        )
+
     def test_patch_memory_prepare_with_diagnostics_sets_no_match_status(self) -> None:
         class FakeManager:
             def __init__(self):
@@ -1178,7 +1351,7 @@ class MemoryFactoryTests(unittest.TestCase):
         self.assertEqual(prepared, [{"role": "assistant", "content": "ok"}])
         self.assertEqual(manager._last_prepare_info["vector_recall_status"], "search_failed")
 
-    def test_patch_memory_prepare_with_diagnostics_sanitizes_and_cleans_store(self) -> None:
+    def test_patch_memory_prepare_with_diagnostics_sanitizes_without_prewrite(self) -> None:
         class FakeStore:
             def __init__(self, state):
                 self.state = copy.deepcopy(state)
@@ -1218,6 +1391,19 @@ class MemoryFactoryTests(unittest.TestCase):
                             },
                         ],
                         "session_meta": "keep",
+                        "execution_checkpoint": {
+                            "checkpoint_id": "checkpoint-1",
+                            "replay_frame": {
+                                "format": "openai.responses.v1",
+                                "complete": True,
+                                "items": [
+                                    {
+                                        "type": "reasoning",
+                                        "encrypted_content": "opaque",
+                                    }
+                                ],
+                            },
+                        },
                     }
                 )
                 self.received_incoming = None
@@ -1305,13 +1491,20 @@ class MemoryFactoryTests(unittest.TestCase):
                 {"role": "assistant", "content": [{"type": "text", "text": "reply"}]},
             ],
         )
-        self.assertGreaterEqual(len(manager.store.saved_states), 1)
+        self.assertEqual(manager.store.saved_states, [])
+        self.assertEqual(manager.store.state["session_meta"], "keep")
+        self.assertTrue(
+            any(
+                message.get("role") == "tool"
+                for message in manager.store.state["messages"]
+                if isinstance(message, dict)
+            )
+        )
         self.assertEqual(
-            manager.store.state,
-            {
-                "messages": [{"role": "user", "content": "old"}],
-                "session_meta": "keep",
-            },
+            manager.store.state["execution_checkpoint"]["replay_frame"]["items"][0][
+                "encrypted_content"
+            ],
+            "opaque",
         )
 
     def test_patch_memory_prepare_with_diagnostics_ignores_log_encoding_failures(self) -> None:

--- a/unchain_runtime/server/tests/test_models_catalog_route.py
+++ b/unchain_runtime/server/tests/test_models_catalog_route.py
@@ -757,6 +757,30 @@ class ModelsCatalogRouteTests(unittest.TestCase):
         self.assertEqual(payload["error"]["code"], "invalid_request")
         self.assertEqual(payload["error"]["message"], "messages must be an array")
 
+    def test_replace_memory_session_returns_revision_conflict_as_409(self) -> None:
+        class RevisionConflict(RuntimeError):
+            code = "session_revision_conflict"
+            expected_revision = 4
+            actual_revision = 5
+
+        fake_memory_factory = types.SimpleNamespace(
+            replace_short_term_session_memory=mock.Mock(
+                side_effect=RevisionConflict("stale session writer")
+            )
+        )
+
+        with mock.patch.dict(sys.modules, {"memory_factory": fake_memory_factory}):
+            response = self.client.post(
+                "/memory/session/replace",
+                json={"session_id": "chat-1", "messages": []},
+            )
+
+        self.assertEqual(response.status_code, 409)
+        payload = response.get_json()["error"]
+        self.assertEqual(payload["code"], "session_revision_conflict")
+        self.assertEqual(payload["expected_revision"], 4)
+        self.assertEqual(payload["actual_revision"], 5)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unchain_runtime/server/tests/test_unchain_adapter_recipe_graph_runtime.py
+++ b/unchain_runtime/server/tests/test_unchain_adapter_recipe_graph_runtime.py
@@ -55,6 +55,214 @@ class FakeAgent:
 
 
 class RecipeGraphRuntimeTests(unittest.TestCase):
+    def test_stream_recipe_graph_rejects_memory_owned_full_history_before_agent_run(self):
+        import unchain_adapter as ua
+        from unchain.memory import InMemorySessionStore, MemoryManager
+
+        recipe = parse_recipe_json(_recipe_dict())
+        store = InMemorySessionStore()
+        store.save(
+            "s",
+            {
+                "messages": [
+                    {"role": "user", "content": "old user"},
+                    {"role": "assistant", "content": "old assistant"},
+                ]
+            },
+        )
+        memory_manager = MemoryManager(store=store)
+
+        with mock.patch.object(ua, "_UnchainAgent", object), \
+             mock.patch.object(ua, "_build_developer_agent") as build_agent, \
+             mock.patch.object(
+                 ua,
+                 "_resolve_memory_runtime",
+                 return_value=(
+                     {"requested": True, "available": True, "reason": ""},
+                     memory_manager,
+                 ),
+             ), \
+             mock.patch.object(ua, "_build_requested_toolkits", return_value=[]):
+            with self.assertRaisesRegex(RuntimeError, "session history ownership conflict"):
+                list(
+                    ua._stream_recipe_graph_events(
+                        recipe=recipe,
+                        message="new user",
+                        history=[
+                            {"role": "user", "content": "old user"},
+                            {"role": "assistant", "content": "old assistant"},
+                        ],
+                        attachments=[],
+                        options={"modelId": "ollama:test", "memory_enabled": True},
+                        session_id="s",
+                    )
+                )
+
+        build_agent.assert_not_called()
+
+    def test_stream_recipe_graph_rethrows_checkpoint_resume_required_before_agent_run(self):
+        import unchain_adapter as ua
+
+        recipe = parse_recipe_json(_recipe_dict())
+
+        class CheckpointResumeRequired(RuntimeError):
+            code = "execution_checkpoint_resume_required"
+
+        class CheckpointMemoryManager:
+            def __init__(self):
+                self.prepare_calls = 0
+                self.commit_calls = 0
+
+            def prepare_messages(self, **_kwargs):
+                self.prepare_calls += 1
+                raise CheckpointResumeRequired("checkpoint must be resumed")
+
+            def commit_messages(self, **_kwargs):
+                self.commit_calls += 1
+
+        memory_manager = CheckpointMemoryManager()
+        events = []
+
+        with mock.patch.object(ua, "_UnchainAgent", object), \
+             mock.patch.object(ua, "_build_developer_agent") as build_agent, \
+             mock.patch.object(
+                 ua,
+                 "_resolve_memory_runtime",
+                 return_value=(
+                     {"requested": True, "available": True, "reason": ""},
+                     memory_manager,
+                 ),
+             ), \
+             mock.patch.object(ua, "_build_requested_toolkits", return_value=[]):
+            with self.assertRaisesRegex(RuntimeError, "checkpoint must be resumed"):
+                for event in ua._stream_recipe_graph_events(
+                    recipe=recipe,
+                    message="new user",
+                    history=[],
+                    attachments=[],
+                    options={"modelId": "ollama:test", "memory_enabled": True},
+                    session_id="s",
+                ):
+                    events.append(event)
+
+        self.assertEqual(events, [])
+        self.assertEqual(memory_manager.prepare_calls, 1)
+        self.assertEqual(memory_manager.commit_calls, 0)
+        build_agent.assert_not_called()
+
+    def test_stream_recipe_graph_keeps_fallback_for_non_ownership_memory_failure(self):
+        import unchain_adapter as ua
+
+        recipe = parse_recipe_json(_recipe_dict())
+        built = []
+
+        class BrokenMemoryManager:
+            def __init__(self):
+                self.commit_calls = 0
+
+            def prepare_messages(self, **_kwargs):
+                raise RuntimeError("vector backend unavailable")
+
+            def commit_messages(self, **_kwargs):
+                self.commit_calls += 1
+                return None
+
+        broken_memory = BrokenMemoryManager()
+
+        def fake_build(**kwargs):
+            agent = FakeAgent(kwargs["recipe"].agent.prompt, kwargs["toolkits"])
+            built.append(agent)
+            return agent
+
+        with mock.patch.object(ua, "_UnchainAgent", object), \
+             mock.patch.object(ua, "_build_developer_agent", side_effect=fake_build), \
+             mock.patch.object(
+                 ua,
+                 "_resolve_memory_runtime",
+                 return_value=(
+                     {"requested": True, "available": True, "reason": ""},
+                     broken_memory,
+                 ),
+             ), \
+             mock.patch.object(ua, "_build_requested_toolkits", return_value=[]), \
+             mock.patch.object(ua, "_build_bundle_from_result", return_value={}):
+            events = list(
+                ua._stream_recipe_graph_events(
+                    recipe=recipe,
+                    message="new user",
+                    history=[],
+                    attachments=[],
+                    options={"modelId": "ollama:test", "memory_enabled": True},
+                    session_id="s",
+                )
+            )
+
+        self.assertEqual(len(built), 2)
+        self.assertTrue(
+            any(
+                event.get("type") == "memory_prepare"
+                and event.get("applied") is False
+                and "vector backend unavailable" in str(event.get("fallback_reason") or "")
+                for event in events
+            )
+        )
+        self.assertEqual(broken_memory.commit_calls, 0)
+
+    def test_stream_recipe_graph_forwards_prepare_revision_to_commit(self):
+        import unchain_adapter as ua
+
+        recipe = parse_recipe_json(_recipe_dict())
+
+        class RevisionMemoryManager:
+            def __init__(self):
+                self._last_prepare_info = {"session_revision": 7}
+                self._last_commit_info = {}
+                self.expected_revision = None
+
+            @property
+            def last_prepare_info(self):
+                return dict(self._last_prepare_info)
+
+            @property
+            def last_commit_info(self):
+                return dict(self._last_commit_info)
+
+            def prepare_messages(self, **kwargs):
+                return list(kwargs["incoming"])
+
+            def commit_messages(self, *, expected_revision=None, **_kwargs):
+                self.expected_revision = expected_revision
+
+        manager = RevisionMemoryManager()
+
+        def fake_build(**kwargs):
+            return FakeAgent(kwargs["recipe"].agent.prompt, kwargs["toolkits"])
+
+        with mock.patch.object(ua, "_UnchainAgent", object), \
+             mock.patch.object(ua, "_build_developer_agent", side_effect=fake_build), \
+             mock.patch.object(
+                 ua,
+                 "_resolve_memory_runtime",
+                 return_value=(
+                     {"requested": True, "available": True, "reason": ""},
+                     manager,
+                 ),
+             ), \
+             mock.patch.object(ua, "_build_requested_toolkits", return_value=[]), \
+             mock.patch.object(ua, "_build_bundle_from_result", return_value={}):
+            list(
+                ua._stream_recipe_graph_events(
+                    recipe=recipe,
+                    message="new user",
+                    history=[],
+                    attachments=[],
+                    options={"modelId": "ollama:test", "memory_enabled": True},
+                    session_id="s",
+                )
+            )
+
+        self.assertEqual(manager.expected_revision, 7)
+
     def test_stream_recipe_graph_runs_agents_in_order_and_only_final_is_final_message(self):
         import unchain_adapter as ua
 

--- a/unchain_runtime/server/unchain_adapter.py
+++ b/unchain_runtime/server/unchain_adapter.py
@@ -91,6 +91,14 @@ except ImportError:
     _ToolHistoryCompactionOptimizerConfig = None  # type: ignore
     _ToolPairSafetyOptimizer = None  # type: ignore
 
+try:
+    from unchain.memory import (
+        SessionHistoryOwnershipError as _SessionHistoryOwnershipError,
+    )
+except ImportError:  # pragma: no cover - compatibility with older unchain builds
+    class _SessionHistoryOwnershipError(ValueError):
+        pass
+
 from interaction_channels import (
     register_interject_channels,
     release_interject_channels,
@@ -4703,6 +4711,8 @@ def _stream_recipe_graph_events(
     def run_workflow() -> None:
         try:
             memory_namespace = str(options.get("memory_namespace") or "").strip()
+            memory_session_revision: int | None = None
+            memory_commit_allowed = False
             runtime_messages = base_messages
             if memory_manager is not None:
                 try:
@@ -4720,6 +4730,12 @@ def _stream_recipe_graph_events(
                         supports_tools=True,
                     )
                     prepare_info = getattr(memory_manager, "last_prepare_info", {}) or {}
+                    prepared_revision = prepare_info.get("session_revision")
+                    if isinstance(prepared_revision, int) and not isinstance(
+                        prepared_revision, bool
+                    ):
+                        memory_session_revision = prepared_revision
+                    memory_commit_allowed = True
                     emit({
                         "type": "memory_prepare",
                         "run_id": workflow_run_id,
@@ -4729,6 +4745,14 @@ def _stream_recipe_graph_events(
                         **copy.deepcopy(prepare_info),
                     })
                 except Exception as exc:
+                    error_code = str(getattr(exc, "code", "") or "")
+                    if (
+                        isinstance(exc, _SessionHistoryOwnershipError)
+                        or error_code.startswith("execution_checkpoint_")
+                        or error_code
+                        in {"session_revision_conflict", "session_store_corruption"}
+                    ):
+                        raise
                     emit({
                         "type": "memory_prepare",
                         "run_id": workflow_run_id,
@@ -4923,18 +4947,27 @@ def _stream_recipe_graph_events(
                 output_holder["final_text"] = final_text
 
             final_text = str(output_holder.get("final_text") or "")
-            if memory_manager is not None and final_text:
+            if memory_manager is not None and final_text and memory_commit_allowed:
                 try:
                     commit_messages = [
                         *base_messages,
                         {"role": "assistant", "content": final_text},
                     ]
-                    memory_manager.commit_messages(
-                        session_id=session_id,
-                        full_conversation=commit_messages,
-                        memory_namespace=memory_namespace or None,
-                        model=selected_config["model"],
-                    )
+                    commit_kwargs = {
+                        "session_id": session_id,
+                        "full_conversation": commit_messages,
+                        "memory_namespace": memory_namespace or None,
+                        "model": selected_config["model"],
+                    }
+                    try:
+                        commit_parameters = inspect.signature(
+                            memory_manager.commit_messages
+                        ).parameters
+                    except Exception:
+                        commit_parameters = {}
+                    if "expected_revision" in commit_parameters:
+                        commit_kwargs["expected_revision"] = memory_session_revision
+                    memory_manager.commit_messages(**commit_kwargs)
                     commit_info = getattr(memory_manager, "last_commit_info", {}) or {}
                     emit({
                         "type": "memory_commit",


### PR DESCRIPTION
## Summary

- forward session revisions and compare-and-swap expectations through PuPu memory adapters
- avoid unsafe prewrites before Unchain owns the semantic commit
- return HTTP 409 for stale replacement attempts
- make recipe-graph streaming fail closed when the durable contract cannot be honored
- adopt the winning vector collection tag under concurrent initialization
- add regression coverage for memory wrappers, routes, catalog projection, and recipe-graph runtime behavior

## Dependency

Stacked on https://github.com/haoxiang-xu/unchain/pull/24. This PR should be tested and merged with that Unchain contract available.

## Verification

- PYTHONPATH=/Users/red/Desktop/GITRepo/unchain/src python -m pytest -q unchain_runtime/server/tests: 405 passed, 1 warning
- git diff --check
- scoped GitNexus impact: LOW to MEDIUM for the seven Python files; no scoped HIGH or CRITICAL production symbol

## Scope safety

The branch was created from origin/dev in a clean worktree and contains only seven backend Python files. Existing local PuPu UI edits and six unpublished dev commits were not included.

## Rollout note

Restart the PuPu Python sidecar after the compatible Unchain build is installed or checked out.