### PR TITLE
feat(computer-use): last-mile attach path — settings nav panel + per-chat Computer entry + capability from status

### DIFF
--- a/src/COMPONENTs/chat-input/components/attach_panel.js
+++ b/src/COMPONENTs/chat-input/components/attach_panel.js
@@ -5,6 +5,7 @@ import {
   useContext,
   useEffect,
   useImperativeHandle,
+  useMemo,
   useRef,
   useState,
 } from "react";
@@ -18,6 +19,7 @@ import AttachmentChipList from "./attachment_chip_list";
 import { QueueAttachSection } from "./queue_pile";
 import { WorkspaceModal } from "../../workspace/workspace_modal";
 import useChatInputToolkits from "../hooks/use_chat_input_toolkits";
+import useComputerUseToolkitOption from "../hooks/use_computer_use_toolkit_option";
 import useChatInputWorkspaces from "../hooks/use_chat_input_workspaces";
 import { emitModelCatalogRefresh } from "../../../SERVICEs/model_catalog_refresh";
 import {
@@ -168,6 +170,16 @@ const AttachPanel = forwardRef(({
   const [featureFlags, setFeatureFlags] = useState(() => readFeatureFlags());
   const lastModelSelectorRefreshAt = useRef(0);
   const { toolkitOptions, refreshToolkits } = useChatInputToolkits();
+  const { computerOption, refreshComputerStatus } = useComputerUseToolkitOption({
+    selectedModelId,
+  });
+  /* Append the synthetic "Computer" entry (null unless computer use is on).
+     It is not a catalog toolkit, so it lives outside the catalog-render path
+     and is stitched in only for the menu. */
+  const toolkitOptionsWithComputer = useMemo(
+    () => (computerOption ? [...toolkitOptions, computerOption] : toolkitOptions),
+    [toolkitOptions, computerOption],
+  );
   const { workspaceOptions } = useChatInputWorkspaces();
   const isAgentsFeatureEnabled =
     featureFlags.enable_user_access_to_agents === true;
@@ -234,6 +246,7 @@ const AttachPanel = forwardRef(({
     (next) => {
       if (next) {
         void refreshToolkits();
+        void refreshComputerStatus();
         setOpenSelector("tools");
         return;
       }
@@ -245,7 +258,7 @@ const AttachPanel = forwardRef(({
         setKbIndex(kbReturnIndexRef.current);
       }
     },
-    [refreshToolkits, onRequestInputFocus],
+    [refreshToolkits, refreshComputerStatus, onRequestInputFocus],
   );
 
   const handleWorkspaceOpenChange = useCallback(
@@ -615,7 +628,7 @@ const AttachPanel = forwardRef(({
                 {kbGlow("tools")}
                 <Select
                   multi
-                  options={toolkitOptions}
+                  options={toolkitOptionsWithComputer}
                   value={localToolkits}
                   set_value={handleToolkitsValueChange}
                   filterable={true}

--- a/src/COMPONENTs/chat-input/components/attach_panel.js
+++ b/src/COMPONENTs/chat-input/components/attach_panel.js
@@ -20,6 +20,7 @@ import { QueueAttachSection } from "./queue_pile";
 import { WorkspaceModal } from "../../workspace/workspace_modal";
 import useChatInputToolkits from "../hooks/use_chat_input_toolkits";
 import useComputerUseToolkitOption from "../hooks/use_computer_use_toolkit_option";
+import { COMPUTER_TOOLKIT_ID } from "../utils/computer_use_toolkit_option";
 import useChatInputWorkspaces from "../hooks/use_chat_input_workspaces";
 import { emitModelCatalogRefresh } from "../../../SERVICEs/model_catalog_refresh";
 import {
@@ -170,9 +171,8 @@ const AttachPanel = forwardRef(({
   const [featureFlags, setFeatureFlags] = useState(() => readFeatureFlags());
   const lastModelSelectorRefreshAt = useRef(0);
   const { toolkitOptions, refreshToolkits } = useChatInputToolkits();
-  const { computerOption, refreshComputerStatus } = useComputerUseToolkitOption({
-    selectedModelId,
-  });
+  const { computerOption, shouldDeselectComputer, refreshComputerStatus } =
+    useComputerUseToolkitOption({ selectedModelId });
   /* Append the synthetic "Computer" entry (null unless computer use is on).
      It is not a catalog toolkit, so it lives outside the catalog-render path
      and is stitched in only for the menu. */
@@ -180,6 +180,22 @@ const AttachPanel = forwardRef(({
     () => (computerOption ? [...toolkitOptions, computerOption] : toolkitOptions),
     [toolkitOptions, computerOption],
   );
+
+  /* Reconcile a residual selection: once computer use is DEFINITIVELY not
+     selectable for this chat (master switch off, bridge unavailable, or the
+     current model unsupported), strip "builtin.computer" from the selection
+     through the normal setter — otherwise the entry sits disabled with the id
+     stuck in the payload and the user can only clear ALL tools to remove it.
+     Server truth still gates real mounting; this is a selection-consistency
+     fix. Switching to a supported model + on again simply re-checks the box. */
+  useEffect(() => {
+    if (!shouldDeselectComputer) return;
+    if (!Array.isArray(selectedToolkits)) return;
+    if (!selectedToolkits.includes(COMPUTER_TOOLKIT_ID)) return;
+    handleToolkitsValueChange(
+      selectedToolkits.filter((value) => value !== COMPUTER_TOOLKIT_ID),
+    );
+  }, [shouldDeselectComputer, selectedToolkits, handleToolkitsValueChange]);
   const { workspaceOptions } = useChatInputWorkspaces();
   const isAgentsFeatureEnabled =
     featureFlags.enable_user_access_to_agents === true;

--- a/src/COMPONENTs/chat-input/components/attach_panel.test.js
+++ b/src/COMPONENTs/chat-input/components/attach_panel.test.js
@@ -14,6 +14,7 @@ jest.mock("../hooks/use_computer_use_toolkit_option", () => ({
   __esModule: true,
   default: jest.fn(() => ({
     computerOption: null,
+    shouldDeselectComputer: false,
     refreshComputerStatus: jest.fn(),
   })),
 }));
@@ -122,6 +123,7 @@ describe("AttachPanel toolkit selector refresh", () => {
     useComputerUseToolkitOption.mockReset();
     useComputerUseToolkitOption.mockReturnValue({
       computerOption: null,
+      shouldDeselectComputer: false,
       refreshComputerStatus: jest.fn(),
     });
     useChatInputWorkspaces.mockReset();
@@ -557,6 +559,120 @@ describe("AttachPanel toolkit selector refresh", () => {
 
     fireEvent.click(screen.getByTestId("select-Search plugins..."));
     expect(refreshComputerStatus).toHaveBeenCalledTimes(1);
+  });
+
+  test("strips a residual builtin.computer when the model becomes unsupported", async () => {
+    const onToolkitsChange = jest.fn();
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    // supported model earlier ⇒ selected; now on an unsupported model the entry
+    // is disabled and the hook signals a reconcile
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: {
+        value: "builtin.computer",
+        label: "Computer",
+        disabled: true,
+      },
+      shouldDeselectComputer: true,
+      refreshComputerStatus: jest.fn(),
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="openai:gpt-5"
+        selectedToolkits={["builtin.computer"]}
+        onToolkitsChange={onToolkitsChange}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(onToolkitsChange).toHaveBeenCalledWith([]));
+  });
+
+  test("strips a residual builtin.computer when the master switch is off", async () => {
+    const onToolkitsChange = jest.fn();
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    // switch off ⇒ no entry rendered, but the stale id must be reconciled out
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: null,
+      shouldDeselectComputer: true,
+      refreshComputerStatus: jest.fn(),
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="anthropic:claude-opus-4-8"
+        selectedToolkits={["workspace_toolkit", "builtin.computer"]}
+        onToolkitsChange={onToolkitsChange}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(onToolkitsChange).toHaveBeenCalledWith(["workspace_toolkit"]),
+    );
+  });
+
+  test("keeps builtin.computer selected and re-selectable on a supported model", () => {
+    const onToolkitsChange = jest.fn();
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    // supported + enabled ⇒ no reconcile; the entry stays checked and usable
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: {
+        value: "builtin.computer",
+        label: "Computer",
+        disabled: false,
+      },
+      shouldDeselectComputer: false,
+      refreshComputerStatus: jest.fn(),
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="anthropic:claude-opus-4-8"
+        selectedToolkits={["builtin.computer"]}
+        onToolkitsChange={onToolkitsChange}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    // selection is NOT stripped
+    expect(onToolkitsChange).not.toHaveBeenCalled();
+    // and the entry is present + enabled (re-selectable)
+    const entry = screen.getByTestId("option-builtin.computer");
+    expect(entry).toHaveAttribute("data-disabled", "false");
   });
 });
 

--- a/src/COMPONENTs/chat-input/components/attach_panel.test.js
+++ b/src/COMPONENTs/chat-input/components/attach_panel.test.js
@@ -2,11 +2,20 @@ import React from "react";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import AttachPanel from "./attach_panel";
 import useChatInputToolkits from "../hooks/use_chat_input_toolkits";
+import useComputerUseToolkitOption from "../hooks/use_computer_use_toolkit_option";
 import useChatInputWorkspaces from "../hooks/use_chat_input_workspaces";
 
 jest.mock("../hooks/use_chat_input_toolkits", () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+
+jest.mock("../hooks/use_computer_use_toolkit_option", () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    computerOption: null,
+    refreshComputerStatus: jest.fn(),
+  })),
 }));
 
 jest.mock("../hooks/use_chat_input_workspaces", () => ({
@@ -24,7 +33,22 @@ jest.mock("../../../BUILTIN_COMPONENTs/select/select", () => ({
     search_placeholder,
     dropdown_position = "bottom",
     custom_trigger,
+    multi = false,
+    value,
+    set_value = () => {},
   }) => {
+    const toggleOption = (item) => {
+      if (!item || item.disabled) return;
+      if (multi) {
+        const current = Array.isArray(value) ? value : [];
+        const next = current.includes(item.value)
+          ? current.filter((v) => v !== item.value)
+          : [...current, item.value];
+        set_value(next);
+      } else {
+        set_value(item.value);
+      }
+    };
     const renderOptionLabels = (items = []) =>
       items.flatMap((item) => {
         if (!item) return [];
@@ -35,9 +59,18 @@ jest.mock("../../../BUILTIN_COMPONENTs/select/select", () => ({
           ];
         }
         return [
-          <span key={`option-${item.value || item.label}`}>
+          <button
+            type="button"
+            key={`option-${item.value || item.label}`}
+            data-testid={`option-${item.value || item.label}`}
+            data-disabled={item.disabled ? "true" : "false"}
+            onClick={(event) => {
+              event.stopPropagation();
+              toggleOption(item);
+            }}
+          >
             {item.label || item.value}
-          </span>,
+          </button>,
         ];
       });
 
@@ -86,6 +119,11 @@ describe("AttachPanel toolkit selector refresh", () => {
   beforeEach(() => {
     window.localStorage.clear();
     useChatInputToolkits.mockReset();
+    useComputerUseToolkitOption.mockReset();
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: null,
+      refreshComputerStatus: jest.fn(),
+    });
     useChatInputWorkspaces.mockReset();
     useChatInputWorkspaces.mockReturnValue({ workspaceOptions: [] });
   });
@@ -346,6 +384,179 @@ describe("AttachPanel toolkit selector refresh", () => {
     expect(screen.getByText("GPT-5.5")).toBeInTheDocument();
     expect(screen.queryByText("Agents")).not.toBeInTheDocument();
     expect(screen.queryByText("Research Agent")).not.toBeInTheDocument();
+  });
+
+  test("appends the Computer entry alongside catalog toolkits when present", () => {
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [{ value: "workspace_toolkit", label: "Workspace Files" }],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: {
+        value: "builtin.computer",
+        label: "Computer",
+        disabled: false,
+      },
+      refreshComputerStatus: jest.fn(),
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="anthropic:claude-opus-4-8"
+        selectedToolkits={[]}
+        onToolkitsChange={() => {}}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    // catalog render path is intact (the real toolkit still shows) and the
+    // synthetic entry is stitched in beside it
+    expect(screen.getByTestId("option-workspace_toolkit")).toBeInTheDocument();
+    expect(screen.getByTestId("option-builtin.computer")).toBeInTheDocument();
+  });
+
+  test("omits the Computer entry when the hook yields none (zero trace)", () => {
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [{ value: "workspace_toolkit", label: "Workspace Files" }],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    // default mock already returns computerOption: null
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="openai:gpt-5"
+        selectedToolkits={[]}
+        onToolkitsChange={() => {}}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId("option-workspace_toolkit")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("option-builtin.computer"),
+    ).not.toBeInTheDocument();
+  });
+
+  test("selecting the Computer entry adds builtin.computer to the payload", () => {
+    const onToolkitsChange = jest.fn();
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: {
+        value: "builtin.computer",
+        label: "Computer",
+        disabled: false,
+      },
+      refreshComputerStatus: jest.fn(),
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="anthropic:claude-opus-4-8"
+        selectedToolkits={[]}
+        onToolkitsChange={onToolkitsChange}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("option-builtin.computer"));
+
+    expect(onToolkitsChange).toHaveBeenCalledWith(["builtin.computer"]);
+  });
+
+  test("a disabled Computer entry cannot be selected", () => {
+    const onToolkitsChange = jest.fn();
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: {
+        value: "builtin.computer",
+        label: "Computer",
+        disabled: true,
+      },
+      refreshComputerStatus: jest.fn(),
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedModelId="openai:gpt-5"
+        selectedToolkits={[]}
+        onToolkitsChange={onToolkitsChange}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    const entry = screen.getByTestId("option-builtin.computer");
+    expect(entry).toHaveAttribute("data-disabled", "true");
+    fireEvent.click(entry);
+    expect(onToolkitsChange).not.toHaveBeenCalled();
+  });
+
+  test("refreshes computer-use status when the tools selector opens", () => {
+    const refreshComputerStatus = jest.fn();
+    useChatInputToolkits.mockReturnValue({
+      toolkitOptions: [],
+      toolkitLoading: false,
+      refreshToolkits: jest.fn(),
+    });
+    useComputerUseToolkitOption.mockReturnValue({
+      computerOption: null,
+      refreshComputerStatus,
+    });
+
+    render(
+      <AttachPanel
+        color="#222"
+        active={false}
+        focused={false}
+        onAttachFile={() => {}}
+        isDark={false}
+        attachments={[]}
+        selectedToolkits={[]}
+        onToolkitsChange={() => {}}
+        selectedWorkspaceIds={[]}
+        onWorkspaceIdsChange={() => {}}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("select-Search plugins..."));
+    expect(refreshComputerStatus).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.js
+++ b/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.js
@@ -8,7 +8,9 @@ import {
 } from "../utils/computer_use_toolkit_option";
 
 /**
- * Provides the synthetic "Computer" toolkit option for the chat toolkit menu.
+ * Provides the synthetic "Computer" toolkit option for the chat toolkit menu,
+ * plus a reconcile signal so a residual selection can be stripped when the
+ * entry is no longer selectable.
  *
  * Visibility follows the computer-use master switch (server truth): the option
  * only exists when `getComputerUseStatus().enabled` is true. When the current
@@ -17,17 +19,30 @@ import {
  * the status read fails, the option is null — the caller renders nothing, so
  * the menu is byte-for-byte unchanged (zero-exposure invariant).
  *
+ * `resolution` captures a DEFINITIVE status answer so nothing acts while the
+ * async read is still in flight (which would wrongly strip a supported+enabled
+ * session on every mount):
+ *   - null                                → unknown (initial load, or a read
+ *     error) — render nothing, never reconcile
+ *   - { available: false }                → bridge unavailable — reconcile-strip
+ *   - { available: true, enabled: false } → switch off — reconcile-strip
+ *   - { available: true, enabled: true, supportedModelPrefixes } → switch on
+ *
  * Model capability is computed client-side from the cached prefix list, so it
  * updates reactively as the user switches models without another fetch.
  *
  * @param {{ selectedModelId?: string }} params
- * @returns {{ computerOption: (object|null), refreshComputerStatus: Function }}
+ * @returns {{
+ *   computerOption: (object|null),
+ *   shouldDeselectComputer: boolean,
+ *   refreshComputerStatus: Function,
+ * }}
  */
 const useComputerUseToolkitOption = ({ selectedModelId } = {}) => {
   const { isDark } = useContext(ConfigContext);
   const { t } = useTranslation();
 
-  const [status, setStatus] = useState(null);
+  const [resolution, setResolution] = useState(null);
   const mountedRef = useRef(true);
   const requestIdRef = useRef(0);
 
@@ -40,14 +55,14 @@ const useComputerUseToolkitOption = ({ selectedModelId } = {}) => {
   const refreshComputerStatus = useCallback(async () => {
     const runtime = api.runtime;
     if (!runtime || typeof runtime.getComputerUseStatus !== "function") {
-      if (mountedRef.current) setStatus(null);
+      if (mountedRef.current) setResolution({ available: false });
       return;
     }
     if (
       typeof runtime.isComputerUseStatusAvailable === "function" &&
       !runtime.isComputerUseStatusAvailable()
     ) {
-      if (mountedRef.current) setStatus(null);
+      if (mountedRef.current) setResolution({ available: false });
       return;
     }
 
@@ -57,17 +72,18 @@ const useComputerUseToolkitOption = ({ selectedModelId } = {}) => {
     try {
       const next = await runtime.getComputerUseStatus();
       if (!mountedRef.current || requestId !== requestIdRef.current) return;
-      setStatus({
+      setResolution({
+        available: true,
         enabled: Boolean(next?.enabled),
         supportedModelPrefixes: Array.isArray(next?.supportedModelPrefixes)
           ? next.supportedModelPrefixes
           : [],
       });
     } catch {
-      /* A failed / unavailable status read must not leak a broken entry into
-         the menu — collapse to "no option" rather than showing a stale one. */
-      if (!mountedRef.current || requestId !== requestIdRef.current) return;
-      setStatus(null);
+      /* A failed read is UNKNOWN, not "off": keep the prior resolution (no
+         flicker) and — critically — do NOT reconcile away a selection over a
+         transient sidecar hiccup. Leaving `resolution` untouched keeps
+         shouldDeselectComputer stable. */
     }
   }, []);
 
@@ -75,19 +91,37 @@ const useComputerUseToolkitOption = ({ selectedModelId } = {}) => {
     void refreshComputerStatus();
   }, [refreshComputerStatus]);
 
+  const supportedForModel = useMemo(
+    () =>
+      resolution?.available && resolution?.enabled
+        ? isComputerModelSupported(
+            selectedModelId,
+            resolution.supportedModelPrefixes,
+          )
+        : false,
+    [resolution, selectedModelId],
+  );
+
   const computerOption = useMemo(() => {
-    if (!status?.enabled) return null;
+    if (!resolution?.available || !resolution?.enabled) return null;
     return buildComputerToolkitOption({
       t,
       isDark,
-      supported: isComputerModelSupported(
-        selectedModelId,
-        status.supportedModelPrefixes,
-      ),
+      supported: supportedForModel,
     });
-  }, [status, selectedModelId, t, isDark]);
+  }, [resolution, supportedForModel, t, isDark]);
 
-  return { computerOption, refreshComputerStatus };
+  /* Reconcile only on a DEFINITIVE answer: bridge unavailable, switch off, or
+     switch-on-but-current-model-unsupported. `null` (loading / read error)
+     must not strip. */
+  const shouldDeselectComputer = useMemo(() => {
+    if (!resolution) return false;
+    if (!resolution.available) return true;
+    if (!resolution.enabled) return true;
+    return !supportedForModel;
+  }, [resolution, supportedForModel]);
+
+  return { computerOption, shouldDeselectComputer, refreshComputerStatus };
 };
 
 export default useComputerUseToolkitOption;

--- a/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.js
+++ b/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.js
@@ -1,0 +1,93 @@
+import { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { ConfigContext } from "../../../CONTAINERs/config/context";
+import { useTranslation } from "../../../BUILTIN_COMPONENTs/mini_react/use_translation";
+import api from "../../../SERVICEs/api";
+import {
+  buildComputerToolkitOption,
+  isComputerModelSupported,
+} from "../utils/computer_use_toolkit_option";
+
+/**
+ * Provides the synthetic "Computer" toolkit option for the chat toolkit menu.
+ *
+ * Visibility follows the computer-use master switch (server truth): the option
+ * only exists when `getComputerUseStatus().enabled` is true. When the current
+ * model is not in the sidecar's supported set the option is present but
+ * disabled with a hint. When the switch is off, the bridge is unavailable, or
+ * the status read fails, the option is null — the caller renders nothing, so
+ * the menu is byte-for-byte unchanged (zero-exposure invariant).
+ *
+ * Model capability is computed client-side from the cached prefix list, so it
+ * updates reactively as the user switches models without another fetch.
+ *
+ * @param {{ selectedModelId?: string }} params
+ * @returns {{ computerOption: (object|null), refreshComputerStatus: Function }}
+ */
+const useComputerUseToolkitOption = ({ selectedModelId } = {}) => {
+  const { isDark } = useContext(ConfigContext);
+  const { t } = useTranslation();
+
+  const [status, setStatus] = useState(null);
+  const mountedRef = useRef(true);
+  const requestIdRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const refreshComputerStatus = useCallback(async () => {
+    const runtime = api.runtime;
+    if (!runtime || typeof runtime.getComputerUseStatus !== "function") {
+      if (mountedRef.current) setStatus(null);
+      return;
+    }
+    if (
+      typeof runtime.isComputerUseStatusAvailable === "function" &&
+      !runtime.isComputerUseStatusAvailable()
+    ) {
+      if (mountedRef.current) setStatus(null);
+      return;
+    }
+
+    const requestId = requestIdRef.current + 1;
+    requestIdRef.current = requestId;
+
+    try {
+      const next = await runtime.getComputerUseStatus();
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
+      setStatus({
+        enabled: Boolean(next?.enabled),
+        supportedModelPrefixes: Array.isArray(next?.supportedModelPrefixes)
+          ? next.supportedModelPrefixes
+          : [],
+      });
+    } catch {
+      /* A failed / unavailable status read must not leak a broken entry into
+         the menu — collapse to "no option" rather than showing a stale one. */
+      if (!mountedRef.current || requestId !== requestIdRef.current) return;
+      setStatus(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshComputerStatus();
+  }, [refreshComputerStatus]);
+
+  const computerOption = useMemo(() => {
+    if (!status?.enabled) return null;
+    return buildComputerToolkitOption({
+      t,
+      isDark,
+      supported: isComputerModelSupported(
+        selectedModelId,
+        status.supportedModelPrefixes,
+      ),
+    });
+  }, [status, selectedModelId, t, isDark]);
+
+  return { computerOption, refreshComputerStatus };
+};
+
+export default useComputerUseToolkitOption;

--- a/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.test.js
+++ b/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.test.js
@@ -14,8 +14,18 @@ jest.mock("../../../SERVICEs/api", () => ({
   },
 }));
 
+const createDeferred = () => {
+  let resolve;
+  const promise = new Promise((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+};
+
 const Harness = ({ selectedModelId }) => {
-  const { computerOption } = useComputerUseToolkitOption({ selectedModelId });
+  const { computerOption, shouldDeselectComputer } = useComputerUseToolkitOption({
+    selectedModelId,
+  });
   return (
     <ConfigContext.Provider value={{ isDark: false, theme: {} }}>
       <pre data-testid="option">
@@ -28,6 +38,9 @@ const Harness = ({ selectedModelId }) => {
             })
           : "null"}
       </pre>
+      <pre data-testid="deselect">
+        {shouldDeselectComputer ? "true" : "false"}
+      </pre>
     </ConfigContext.Provider>
   );
 };
@@ -36,6 +49,9 @@ const readOption = () => {
   const text = screen.getByTestId("option").textContent || "null";
   return text === "null" ? null : JSON.parse(text);
 };
+
+const readDeselect = () =>
+  (screen.getByTestId("deselect").textContent || "").trim() === "true";
 
 describe("useComputerUseToolkitOption", () => {
   beforeEach(() => {
@@ -114,5 +130,64 @@ describe("useComputerUseToolkitOption", () => {
       expect(api.runtime.getComputerUseStatus).toHaveBeenCalled(),
     );
     await waitFor(() => expect(readOption()).toBeNull());
+  });
+
+  test("does not signal deselect while the status read is still in flight", async () => {
+    const deferred = createDeferred();
+    api.runtime.getComputerUseStatus.mockReturnValue(deferred.promise);
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    // Unresolved status must NOT strip a selection (would wrongly deselect a
+    // supported+enabled session on every mount).
+    await waitFor(() =>
+      expect(api.runtime.getComputerUseStatus).toHaveBeenCalled(),
+    );
+    expect(readDeselect()).toBe(false);
+
+    deferred.resolve({ enabled: true, supportedModelPrefixes: ["claude-opus"] });
+    await waitFor(() => expect(readDeselect()).toBe(false));
+  });
+
+  test("signals deselect when the master switch is off", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({
+      enabled: false,
+      supportedModelPrefixes: ["claude-opus"],
+    });
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() => expect(readDeselect()).toBe(true));
+  });
+
+  test("signals deselect when the current model is unsupported", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({
+      enabled: true,
+      supportedModelPrefixes: ["claude-opus"],
+    });
+
+    render(<Harness selectedModelId="openai:gpt-5" />);
+
+    await waitFor(() => expect(readDeselect()).toBe(true));
+  });
+
+  test("signals deselect when the status bridge is unavailable", async () => {
+    api.runtime.isComputerUseStatusAvailable.mockReturnValue(false);
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() => expect(readDeselect()).toBe(true));
+  });
+
+  test("does not signal deselect when enabled and the model is supported", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({
+      enabled: true,
+      supportedModelPrefixes: ["claude-opus"],
+    });
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() => expect(readOption()).not.toBeNull());
+    expect(readDeselect()).toBe(false);
   });
 });

--- a/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.test.js
+++ b/src/COMPONENTs/chat-input/hooks/use_computer_use_toolkit_option.test.js
@@ -1,0 +1,118 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import api from "../../../SERVICEs/api";
+import useComputerUseToolkitOption from "./use_computer_use_toolkit_option";
+import { ConfigContext } from "../../../CONTAINERs/config/context";
+
+jest.mock("../../../SERVICEs/api", () => ({
+  __esModule: true,
+  default: {
+    runtime: {
+      isComputerUseStatusAvailable: jest.fn(() => true),
+      getComputerUseStatus: jest.fn(),
+    },
+  },
+}));
+
+const Harness = ({ selectedModelId }) => {
+  const { computerOption } = useComputerUseToolkitOption({ selectedModelId });
+  return (
+    <ConfigContext.Provider value={{ isDark: false, theme: {} }}>
+      <pre data-testid="option">
+        {computerOption
+          ? JSON.stringify({
+              value: computerOption.value,
+              disabled: computerOption.disabled,
+              label: computerOption.label,
+              description: computerOption.description,
+            })
+          : "null"}
+      </pre>
+    </ConfigContext.Provider>
+  );
+};
+
+const readOption = () => {
+  const text = screen.getByTestId("option").textContent || "null";
+  return text === "null" ? null : JSON.parse(text);
+};
+
+describe("useComputerUseToolkitOption", () => {
+  beforeEach(() => {
+    api.runtime.isComputerUseStatusAvailable.mockReset();
+    api.runtime.isComputerUseStatusAvailable.mockReturnValue(true);
+    api.runtime.getComputerUseStatus.mockReset();
+  });
+
+  test("no option when the master switch is disabled", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({
+      enabled: false,
+      supportedModelPrefixes: ["claude-opus"],
+    });
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() =>
+      expect(api.runtime.getComputerUseStatus).toHaveBeenCalled(),
+    );
+    await waitFor(() => expect(readOption()).toBeNull());
+  });
+
+  test("enabled + supported model yields an active option", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({
+      enabled: true,
+      supportedModelPrefixes: ["claude-opus", "claude-sonnet"],
+    });
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() => expect(readOption()).not.toBeNull());
+    const option = readOption();
+    expect(option.value).toBe("builtin.computer");
+    expect(option.disabled).toBe(false);
+  });
+
+  test("enabled + unsupported model yields a disabled option with hint", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({
+      enabled: true,
+      supportedModelPrefixes: ["claude-opus"],
+    });
+
+    render(<Harness selectedModelId="openai:gpt-5" />);
+
+    await waitFor(() => expect(readOption()).not.toBeNull());
+    const option = readOption();
+    expect(option.value).toBe("builtin.computer");
+    expect(option.disabled).toBe(true);
+    expect(option.description).toBe("Requires a supported Anthropic model");
+  });
+
+  test("missing prefix field (older sidecar) is treated as unsupported", async () => {
+    api.runtime.getComputerUseStatus.mockResolvedValue({ enabled: true });
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() => expect(readOption()).not.toBeNull());
+    expect(readOption().disabled).toBe(true);
+  });
+
+  test("no option when the status bridge is unavailable", async () => {
+    api.runtime.isComputerUseStatusAvailable.mockReturnValue(false);
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() => expect(readOption()).toBeNull());
+    expect(api.runtime.getComputerUseStatus).not.toHaveBeenCalled();
+  });
+
+  test("no option when the status read throws", async () => {
+    api.runtime.getComputerUseStatus.mockRejectedValue(new Error("boom"));
+
+    render(<Harness selectedModelId="anthropic:claude-opus-4-8" />);
+
+    await waitFor(() =>
+      expect(api.runtime.getComputerUseStatus).toHaveBeenCalled(),
+    );
+    await waitFor(() => expect(readOption()).toBeNull());
+  });
+});

--- a/src/COMPONENTs/chat-input/utils/computer_use_toolkit_option.js
+++ b/src/COMPONENTs/chat-input/utils/computer_use_toolkit_option.js
@@ -1,0 +1,102 @@
+import Icon from "../../../BUILTIN_COMPONENTs/icon/icon";
+
+/**
+ * The canonical toolkit id the sidecar funnel recognizes for computer use.
+ * This is a SYNTHETIC menu entry — it is NOT part of the MCP toolkit catalog,
+ * so nothing in the catalog-render path produces it. When selected, this id
+ * simply rides the existing chat toolkit payload; the sidecar mounts the
+ * builtin computer tool only when its runtime flag is on, the model supports
+ * it, and the turn is not a subagent (server is authoritative).
+ */
+export const COMPUTER_TOOLKIT_ID = "builtin.computer";
+
+/** Builtin icon (cursor/pointer) used for the Computer menu entry. */
+const COMPUTER_TOOLKIT_ICON = "mouse";
+
+const ICON_BOX_SIZE = 24;
+const ICON_GLYPH_SIZE = 16;
+
+/**
+ * Strip a provider prefix from a model id: "anthropic:claude-opus-4-8"
+ * becomes "claude-opus-4-8". A value with no provider colon is returned
+ * as-is. Custom providers ("custom.foo:model") strip to "model".
+ *
+ * @param {string} modelId
+ * @returns {string}
+ */
+export const stripModelProviderPrefix = (modelId) => {
+  if (typeof modelId !== "string") return "";
+  const trimmed = modelId.trim();
+  if (!trimmed) return "";
+  const colonIndex = trimmed.indexOf(":");
+  return colonIndex === -1 ? trimmed : trimmed.slice(colonIndex + 1);
+};
+
+/**
+ * Whether the current chat model supports computer use, per the sidecar's
+ * capability contract: the provider-stripped model id must start with one of
+ * the supported prefixes. An empty / missing prefix list (older sidecar)
+ * reads as "no supported models" ⇒ unsupported.
+ *
+ * @param {string} modelId — e.g. "anthropic:claude-opus-4-8"
+ * @param {Array<string>} supportedPrefixes — bare id prefixes
+ * @returns {boolean}
+ */
+export const isComputerModelSupported = (modelId, supportedPrefixes) => {
+  if (!Array.isArray(supportedPrefixes) || supportedPrefixes.length === 0) {
+    return false;
+  }
+  const bareId = stripModelProviderPrefix(modelId);
+  if (!bareId) return false;
+  return supportedPrefixes.some(
+    (prefix) =>
+      typeof prefix === "string" && prefix !== "" && bareId.startsWith(prefix),
+  );
+};
+
+const buildComputerToolkitIcon = (isDark) => (
+  <span
+    aria-hidden="true"
+    style={{
+      width: ICON_BOX_SIZE,
+      height: ICON_BOX_SIZE,
+      borderRadius: 6,
+      display: "inline-flex",
+      alignItems: "center",
+      justifyContent: "center",
+      backgroundColor: isDark
+        ? "rgba(148,163,184,0.18)"
+        : "rgba(148,163,184,0.14)",
+      flexShrink: 0,
+    }}
+  >
+    <Icon
+      src={COMPUTER_TOOLKIT_ICON}
+      style={{ width: ICON_GLYPH_SIZE, height: ICON_GLYPH_SIZE }}
+    />
+  </span>
+);
+
+/**
+ * Build the synthetic "Computer" Select option for the chat toolkit menu.
+ * When the model is unsupported the option is disabled and its description
+ * becomes the short "needs a supported model" hint.
+ *
+ * @param {{ t: Function, isDark: boolean, supported: boolean }} params
+ * @returns {object} Select-compatible option
+ */
+export const buildComputerToolkitOption = ({ t, isDark, supported }) => {
+  const label = t("chat.attach.computer");
+  return {
+    value: COMPUTER_TOOLKIT_ID,
+    label,
+    description: supported
+      ? t("chat.attach.computer_description")
+      : t("chat.attach.computer_requires_supported_model"),
+    disabled: !supported,
+    icon: buildComputerToolkitIcon(isDark),
+    search: `${label} ${COMPUTER_TOOLKIT_ID} computer`,
+  };
+};
+
+export default buildComputerToolkitOption;

--- a/src/COMPONENTs/chat-input/utils/computer_use_toolkit_option.test.js
+++ b/src/COMPONENTs/chat-input/utils/computer_use_toolkit_option.test.js
@@ -1,0 +1,87 @@
+import {
+  COMPUTER_TOOLKIT_ID,
+  buildComputerToolkitOption,
+  isComputerModelSupported,
+  stripModelProviderPrefix,
+} from "./computer_use_toolkit_option";
+
+describe("stripModelProviderPrefix", () => {
+  test("removes the provider prefix up to the first colon", () => {
+    expect(stripModelProviderPrefix("anthropic:claude-opus-4-8")).toBe(
+      "claude-opus-4-8",
+    );
+  });
+
+  test("strips only the first colon segment for custom providers", () => {
+    expect(stripModelProviderPrefix("custom.acme:claude-3")).toBe("claude-3");
+  });
+
+  test("returns a bare id (no colon) unchanged", () => {
+    expect(stripModelProviderPrefix("claude-opus-4-8")).toBe("claude-opus-4-8");
+  });
+
+  test("handles non-string / empty input", () => {
+    expect(stripModelProviderPrefix(undefined)).toBe("");
+    expect(stripModelProviderPrefix(null)).toBe("");
+    expect(stripModelProviderPrefix("   ")).toBe("");
+  });
+});
+
+describe("isComputerModelSupported", () => {
+  test("matches when the stripped id starts with a supported prefix", () => {
+    expect(
+      isComputerModelSupported("anthropic:claude-opus-4-8", ["claude-opus"]),
+    ).toBe(true);
+  });
+
+  test("does not match a different family", () => {
+    expect(
+      isComputerModelSupported("openai:gpt-5", ["claude-opus", "claude-sonnet"]),
+    ).toBe(false);
+  });
+
+  test("treats a missing / empty prefix list as unsupported", () => {
+    expect(isComputerModelSupported("anthropic:claude-opus-4-8", [])).toBe(
+      false,
+    );
+    expect(
+      isComputerModelSupported("anthropic:claude-opus-4-8", undefined),
+    ).toBe(false);
+  });
+
+  test("ignores empty / non-string prefixes", () => {
+    expect(
+      isComputerModelSupported("anthropic:claude-opus-4-8", ["", null, "claude"]),
+    ).toBe(true);
+    expect(isComputerModelSupported("anthropic:claude-opus-4-8", ["", null])).toBe(
+      false,
+    );
+  });
+});
+
+describe("buildComputerToolkitOption", () => {
+  const t = (key) => key;
+
+  test("uses the canonical builtin.computer id and is enabled when supported", () => {
+    const option = buildComputerToolkitOption({ t, isDark: false, supported: true });
+    expect(option.value).toBe(COMPUTER_TOOLKIT_ID);
+    expect(option.value).toBe("builtin.computer");
+    expect(option.disabled).toBe(false);
+    expect(option.label).toBe("chat.attach.computer");
+    expect(option.description).toBe("chat.attach.computer_description");
+    expect(option.icon).toBeTruthy();
+  });
+
+  test("is disabled with the requires-model hint when unsupported", () => {
+    const option = buildComputerToolkitOption({ t, isDark: true, supported: false });
+    expect(option.disabled).toBe(true);
+    expect(option.description).toBe(
+      "chat.attach.computer_requires_supported_model",
+    );
+  });
+
+  test("carries a search string that includes the id", () => {
+    const option = buildComputerToolkitOption({ t, isDark: false, supported: true });
+    expect(option.search).toContain("builtin.computer");
+  });
+});

--- a/src/COMPONENTs/settings/dev/index.js
+++ b/src/COMPONENTs/settings/dev/index.js
@@ -14,7 +14,6 @@ import { readDevSettings, writeDevSettings } from "./storage";
 import { useTranslation } from "../../../BUILTIN_COMPONENTs/mini_react/use_translation";
 import UITestingModal from "../../ui-testing/ui_testing_modal";
 import McpRegistriesModal from "./components/mcp_registries_modal";
-import ComputerUseSettings from "../computer_use";
 
 export const DevSettings = () => {
   const { theme, onThemeMode } = useContext(ConfigContext);
@@ -285,8 +284,6 @@ export const DevSettings = () => {
           </div>
         )}
       </SettingsSection>
-
-      <ComputerUseSettings />
     </div>
   );
 };

--- a/src/COMPONENTs/settings/dev/index.test.js
+++ b/src/COMPONENTs/settings/dev/index.test.js
@@ -63,11 +63,6 @@ jest.mock("./components/mcp_registries_modal", () => ({
   default: ({ open }) => (open ? <div>MCP Registries Modal</div> : null),
 }));
 
-jest.mock("../computer_use", () => ({
-  __esModule: true,
-  default: () => <div>Computer Use Settings</div>,
-}));
-
 describe("DevSettings", () => {
   test("opens MCP Registries in a modal from a Developer row", () => {
     render(<DevSettings />);

--- a/src/COMPONENTs/settings/settings_modal.test.js
+++ b/src/COMPONENTs/settings/settings_modal.test.js
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { ConfigContext, LocaleContext } from "../../CONTAINERs/config/context";
 import { SettingsModal } from "./settings_modal";
 
@@ -49,6 +49,11 @@ jest.mock("./token_usage", () => ({
   TokenUsageSettings: () => <div>Token Usage Content</div>,
 }));
 
+jest.mock("./computer_use", () => ({
+  __esModule: true,
+  ComputerUseSettings: () => <div>Computer Use Content</div>,
+}));
+
 jest.mock("./dev", () => ({
   __esModule: true,
   DevSettings: () => <div>Dev Content</div>,
@@ -77,6 +82,16 @@ describe("SettingsModal", () => {
     renderSettingsModal();
 
     expect(await screen.findByText("Update")).toBeInTheDocument();
+  });
+
+  test("renders the Computer Use page from the main settings nav", async () => {
+    renderSettingsModal();
+
+    await screen.findByText("Appearance Content");
+    // The Computer Use nav entry lives in the main settings area (not dev).
+    fireEvent.click(screen.getByText("Computer Use"));
+
+    expect(await screen.findByText("Computer Use Content")).toBeInTheDocument();
   });
 
   test("hides the Update page when the app update feature flag is disabled", async () => {

--- a/src/COMPONENTs/settings/settings_modal_content.js
+++ b/src/COMPONENTs/settings/settings_modal_content.js
@@ -8,6 +8,7 @@ import { MemorySettings } from "./memory";
 import { RuntimeSettings } from "./runtime";
 import { AppUpdateSettings } from "./app_update";
 import { TokenUsageSettings } from "./token_usage";
+import { ComputerUseSettings } from "./computer_use";
 import { DevSettings } from "./dev";
 import { isDevSettingsAvailable } from "./dev/storage";
 import {
@@ -21,6 +22,7 @@ const PAGE_COMPONENTS = {
   model_providers: ModelProvidersSettings,
   runtime: RuntimeSettings,
   memory: MemorySettings,
+  computer_use: ComputerUseSettings,
   token_usage: TokenUsageSettings,
   app_update: AppUpdateSettings,
   local_storage: LocalStorageSettings,
@@ -32,6 +34,7 @@ const BASE_SETTINGS_PAGES = [
   { key: "model_providers", icon: "pentagon", labelKey: "settings.model_providers" },
   { key: "runtime", icon: "folder_2", labelKey: "settings.workspaces" },
   { key: "memory", icon: "brain", labelKey: "settings.memory" },
+  { key: "computer_use", icon: "screenshot", labelKey: "settings.computer_use" },
   { key: "token_usage", icon: "bar_chart", labelKey: "settings.token_usage" },
   { key: "app_update", icon: "download_cloud", labelKey: "settings.update" },
   { key: "local_storage", icon: "data", labelKey: "settings.local_storage" },

--- a/src/SERVICEs/bridges/bridges.test.js
+++ b/src/SERVICEs/bridges/bridges.test.js
@@ -213,6 +213,37 @@ describe("bridge wrappers", () => {
     ).rejects.toMatchObject({ code: "bridge_unavailable" });
   });
 
+  test("runtimeBridge.getComputerUseStatus normalizes supported_model_prefixes into a trimmed list", async () => {
+    window.unchainAPI = {
+      getComputerUseStatus: jest.fn(async () => ({
+        enabled: true,
+        reason: "",
+        capabilities: { platform: "darwin" },
+        supported_model_prefixes: ["claude-opus", "  claude-sonnet  ", "", 42],
+      })),
+    };
+
+    await expect(runtimeBridge.getComputerUseStatus()).resolves.toEqual({
+      enabled: true,
+      reason: "",
+      capabilities: { platform: "darwin" },
+      supportedModelPrefixes: ["claude-opus", "claude-sonnet"],
+    });
+  });
+
+  test("runtimeBridge.getComputerUseStatus defaults supportedModelPrefixes to [] when absent", async () => {
+    window.unchainAPI = {
+      getComputerUseStatus: jest.fn(async () => ({ enabled: false })),
+    };
+
+    await expect(runtimeBridge.getComputerUseStatus()).resolves.toEqual({
+      enabled: false,
+      reason: "",
+      capabilities: null,
+      supportedModelPrefixes: [],
+    });
+  });
+
   test("runtimeBridge.syncBuildFeatureFlagsSnapshot forwards flags and normalizes payload", async () => {
     window.unchainAPI = {
       syncBuildFeatureFlagsSnapshot: jest.fn(async (featureFlags) => ({

--- a/src/SERVICEs/bridges/unchain_bridge.js
+++ b/src/SERVICEs/bridges/unchain_bridge.js
@@ -84,11 +84,21 @@ export const runtimeBridge = {
       payload.capabilities && typeof payload.capabilities === "object"
         ? payload.capabilities
         : null;
+    /* Model-capability contract: the sidecar reports which model families
+       support computer use as a list of id prefixes (compared against the
+       provider-stripped model id). Absent on older sidecars — normalize to an
+       empty list so a missing field reads as "no supported models". */
+    const supportedModelPrefixes = Array.isArray(payload.supported_model_prefixes)
+      ? payload.supported_model_prefixes
+          .map((prefix) => (typeof prefix === "string" ? prefix.trim() : ""))
+          .filter(Boolean)
+      : [];
 
     return {
       enabled: Boolean(payload.enabled),
       reason: typeof payload.reason === "string" ? payload.reason : "",
       capabilities,
+      supportedModelPrefixes,
     };
   },
 

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -5,6 +5,7 @@
     "model_providers": "Anbieter",
     "workspaces": "Arbeitsbereich",
     "memory": "Speicher",
+    "computer_use": "Computernutzung",
     "token_usage": "Tokens",
     "update": "Update",
     "local_storage": "Speicher",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -472,7 +472,10 @@
       "screenshot": "Take a screenshot",
       "screenshot_unsupported": "Current model does not support image inputs",
       "select_toolkits": "Select plugins",
-      "select_workspaces": "Select workspaces"
+      "select_workspaces": "Select workspaces",
+      "computer": "Computer",
+      "computer_description": "Let the model see and control your screen",
+      "computer_requires_supported_model": "Requires a supported Anthropic model"
     }
   },
   "toolkit": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,6 +5,7 @@
     "model_providers": "Model Providers",
     "workspaces": "Workspaces",
     "memory": "Memory",
+    "computer_use": "Computer Use",
     "token_usage": "Token Usage",
     "update": "Update",
     "local_storage": "Local Storage",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -5,6 +5,7 @@
     "model_providers": "Proveedores",
     "workspaces": "Espacios",
     "memory": "Memoria",
+    "computer_use": "Uso del ordenador",
     "token_usage": "Tokens",
     "update": "Actualizar",
     "local_storage": "Almacenamiento",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -5,6 +5,7 @@
     "model_providers": "Fournisseurs",
     "workspaces": "Espaces",
     "memory": "Mémoire",
+    "computer_use": "Contrôle de l'ordinateur",
     "token_usage": "Tokens",
     "update": "Mise à jour",
     "local_storage": "Stockage",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -5,6 +5,7 @@
     "model_providers": "Provider",
     "workspaces": "Spazi",
     "memory": "Memoria",
+    "computer_use": "Uso del computer",
     "token_usage": "Token",
     "update": "Aggiorna",
     "local_storage": "Archivio",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -5,6 +5,7 @@
     "model_providers": "プロバイダー",
     "workspaces": "ワークスペース",
     "memory": "メモリ",
+    "computer_use": "コンピュータ操作",
     "token_usage": "トークン",
     "update": "アップデート",
     "local_storage": "ストレージ",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -5,6 +5,7 @@
     "model_providers": "프로바이더",
     "workspaces": "워크스페이스",
     "memory": "메모리",
+    "computer_use": "컴퓨터 사용",
     "token_usage": "토큰",
     "update": "업데이트",
     "local_storage": "스토리지",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -5,6 +5,7 @@
     "model_providers": "Provedores",
     "workspaces": "Espaços",
     "memory": "Memória",
+    "computer_use": "Uso do computador",
     "token_usage": "Tokens",
     "update": "Atualizar",
     "local_storage": "Armazenamento",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -5,6 +5,7 @@
     "model_providers": "Провайдеры",
     "workspaces": "Воркспейс",
     "memory": "Память",
+    "computer_use": "Управление компьютером",
     "token_usage": "Токены",
     "update": "Обновление",
     "local_storage": "Хранилище",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -5,6 +5,7 @@
     "model_providers": "模型提供商",
     "workspaces": "工作区",
     "memory": "记忆",
+    "computer_use": "电脑操作",
     "token_usage": "Token 用量",
     "update": "更新",
     "local_storage": "本地存储",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -5,6 +5,7 @@
     "model_providers": "模型供應商",
     "workspaces": "工作區",
     "memory": "記憶",
+    "computer_use": "電腦操作",
     "token_usage": "Token 用量",
     "update": "更新",
     "local_storage": "本機儲存",

--- a/unchain_runtime/server/computer_use_flag.py
+++ b/unchain_runtime/server/computer_use_flag.py
@@ -26,6 +26,24 @@ import os
 _COMPUTER_USE_FLAG = "PUPU_COMPUTER_USE"
 _FLAG_TRUE_VALUES = {"1", "true", "yes", "on", "enabled"}
 
+# Anthropic models that support the computer_20251124 tool + the
+# computer-use-2025-11-24 beta. Prefix match tolerates date/@ suffixes. Older
+# Anthropic models (Sonnet 4.5, Haiku 4.5, Opus 4.1, ...) need the OLD tool type
+# + beta and would 400 on ours, so we do NOT mount the computer tool for them
+# (generic-schema fallback is untested M3 work — deliberately not opened here).
+# List is pupu-llm-expert authored (model-visible authority). It lives here in the
+# gate leaf module — beside is_enabled() — so the adapter mount decision and the
+# status route (GET /computer-use/status) read the SAME source. The route stays
+# on this light module and never imports the heavy adapter for the list.
+COMPUTER_USE_MODEL_PREFIXES = (
+    "claude-sonnet-5",
+    "claude-opus-4-8",
+    "claude-opus-4-7",
+    "claude-opus-4-6",
+    "claude-sonnet-4-6",
+    "claude-opus-4-5",
+)
+
 # The user-writable expected state, pushed in via POST /computer-use/config. None
 # means "unset" — defer to the env default. A fresh/restarted process resets to
 # None (fail-closed off until the renderer re-pushes its expected state).

--- a/unchain_runtime/server/route_computer_use.py
+++ b/unchain_runtime/server/route_computer_use.py
@@ -79,8 +79,14 @@ def get_computer_use_status():
     if not root._is_authorized():
         return root._json_error("unauthorized", "Invalid auth token", 401)
 
-    from computer_use_flag import is_enabled
+    from computer_use_flag import COMPUTER_USE_MODEL_PREFIXES, is_enabled
     from computer_control import get_capabilities
+
+    # Single-source model allow-list (pupu-llm-expert authored, held in the gate
+    # module). The chat tool menu reads this to decide whether to surface the
+    # "Computer" entry for the active model — the frontend must never keep its own
+    # copy. Static + probe-independent, so it's present even on a probe failure.
+    supported_model_prefixes = list(COMPUTER_USE_MODEL_PREFIXES)
 
     try:
         capabilities = get_capabilities()
@@ -89,6 +95,7 @@ def get_computer_use_status():
             {
                 "enabled": is_enabled(),
                 "capabilities": None,
+                "supported_model_prefixes": supported_model_prefixes,
                 "error": f"capability_probe_failed: {exc}",
             }
         )
@@ -97,6 +104,7 @@ def get_computer_use_status():
         {
             "enabled": is_enabled(),
             "capabilities": capabilities,
+            "supported_model_prefixes": supported_model_prefixes,
         }
     )
 

--- a/unchain_runtime/server/tests/test_tool_media_and_computer_use_routes.py
+++ b/unchain_runtime/server/tests/test_tool_media_and_computer_use_routes.py
@@ -228,11 +228,34 @@ class ComputerUseRouteTests(_MediaDirTestCase):
         self.assertIn("screen_recording", caps["permissions"])
         self.assertIn("accessibility", caps["permissions"])
 
+    def test_status_exposes_supported_model_prefixes(self):
+        # The chat tool menu reads this list to decide whether to surface the
+        # "Computer" entry; it must match the single-source gate constant exactly
+        # (frontend must never keep its own copy).
+        import computer_use_flag
+
+        os.environ["PUPU_COMPUTER_USE"] = "1"
+        try:
+            resp = self.client.get("/computer-use/status")
+        finally:
+            os.environ.pop("PUPU_COMPUTER_USE", None)
+        self.assertEqual(resp.status_code, 200)
+        body = resp.get_json()
+        self.assertIn("supported_model_prefixes", body)
+        self.assertEqual(
+            body["supported_model_prefixes"],
+            list(computer_use_flag.COMPUTER_USE_MODEL_PREFIXES),
+        )
+
     def test_status_reflects_flag_off(self):
         os.environ.pop("PUPU_COMPUTER_USE", None)
         resp = self.client.get("/computer-use/status")
         self.assertEqual(resp.status_code, 200)
-        self.assertFalse(resp.get_json()["enabled"])
+        body = resp.get_json()
+        self.assertFalse(body["enabled"])
+        # The allow-list is static / probe-independent, so it's present even with
+        # the feature flag off.
+        self.assertIn("supported_model_prefixes", body)
 
 
 if __name__ == "__main__":

--- a/unchain_runtime/server/unchain_adapter.py
+++ b/unchain_runtime/server/unchain_adapter.py
@@ -3350,19 +3350,14 @@ _BUILTIN_TOOLKIT_PREFIX = "builtin."
 # leaf module (Gate B) so a runtime override is observed here and by
 # ``memory_factory``'s screenshot sanitization at once; this file only delegates.
 
-# Anthropic models that support the computer_20251124 tool + the
-# computer-use-2025-11-24 beta. Prefix match tolerates date/@ suffixes. Older
-# Anthropic models (Sonnet 4.5, Haiku 4.5, Opus 4.1, ...) need the OLD tool type
-# + beta and would 400 on ours, so we do NOT mount the computer tool for them
-# (generic-schema fallback is untested M3 work — deliberately not opened here).
-# List is pupu-llm-expert authored (model-visible authority).
-_COMPUTER_USE_MODEL_PREFIXES = (
-    "claude-sonnet-5",
-    "claude-opus-4-8",
-    "claude-opus-4-7",
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-    "claude-opus-4-5",
+# The Anthropic model-prefix allow-list for computer_20251124 now lives in the
+# shared ``computer_use_flag`` gate module (beside is_enabled()) so the status
+# route can read the SAME source without importing this heavy adapter. Re-bound to
+# the local name so ``_model_supports_computer_use`` and its tests are unchanged.
+# The list is pupu-llm-expert authored (model-visible authority) — see that module
+# for the full rationale.
+from computer_use_flag import (
+    COMPUTER_USE_MODEL_PREFIXES as _COMPUTER_USE_MODEL_PREFIXES,
 )
 
 


### PR DESCRIPTION
## Summary

Closes the **last-mile gap** in the Computer Use enable path (#183): with the master switch on, there was no way to actually attach the tool from the real chat UI — the sidecar mounts `builtin.computer` only when a request's toolkits include it, and nothing in the renderer ever sent it (the e2e passed because QA injected toolkits via test-api, masking the gap; found by the CEO asking "why can't I see it").

Three slices (CEO-decided UX: per-chat opt-in entry, not auto-mount — the security-warning system prompt stays out of chats that didn't attach the tool):

1. **Settings panel promoted to first-class** — `ComputerUseSettings` moves out of the dev-only subpage into the main settings nav (after Memory, grouped with the agent-capability pages). All 11 locales get the nav label.
2. **Per-chat "Computer" entry in the chat toolkit menu** (attach panel): visible only when the master switch is on; greyed with a hint when the session model doesn't support computer use; checked → `builtin.computer` rides the existing toolkits payload (no new storage). Synthetic entry — verified it survives every catalog-assuming render path as an opaque id.
3. **`GET /computer-use/status` exposes `supported_model_prefixes`** — the pupu-llm-expert-authored capability list moved (verbatim, with its authority comment) from `unchain_adapter` into the `computer_use_flag` leaf module; the route serves it so the frontend never duplicates the list.

## Review

- **pupu-dev-chat-core** reviewed the attach-panel changes (its surface): opaque-id passthrough, Select multi-value preservation, streaming/session-switch consistency, hook refresh pattern — LGTM; its one SHOULD-FIX (stuck disabled selection after switching to an unsupported model) is fixed via client-side reconcile: when the entry is definitively unselectable (switch off / bridge gone / unsupported model), `builtin.computer` is auto-stripped through the normal setter. Tri-state resolution guards against stripping during the async status load.
- BUILTIN `use_select` disabled semantics untouched (shared primitive).

## User path after this PR

Settings → Computer Use → toggle on (one-time consent) → chat toolkit menu → check "Computer" → talk to a supported Anthropic model (opus-4-8 / sonnet-4-6 / …).

## Test status

- Backend: **854 passed / 3 skipped** (+1 status field test)
- Electron: **121 passed** (untouched)
- Frontend: **2014 passed / 273 suites** (+33 vs dev baseline: visibility tri-state, capability greying, reconcile scenarios, panel relocation, locale keys)
- ESLint on changed files: zero warnings

## Not in this PR

- User-facing **release remains blocked** on the screenshot-injection A/B eval + security final sign-off (tracked; asset pack ready).
- Full i18n for the three chat-menu strings (en-only, falls back to English; nav label is translated in all locales).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
