### PR TITLE
feat(plugins): Computer Use moves into the plugins panel + per-plugin settings contract

### DIFF
--- a/src/COMPONENTs/settings/settings_modal.test.js
+++ b/src/COMPONENTs/settings/settings_modal.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { ConfigContext, LocaleContext } from "../../CONTAINERs/config/context";
 import { SettingsModal } from "./settings_modal";
 
@@ -49,11 +49,6 @@ jest.mock("./token_usage", () => ({
   TokenUsageSettings: () => <div>Token Usage Content</div>,
 }));
 
-jest.mock("./computer_use", () => ({
-  __esModule: true,
-  ComputerUseSettings: () => <div>Computer Use Content</div>,
-}));
-
 jest.mock("./dev", () => ({
   __esModule: true,
   DevSettings: () => <div>Dev Content</div>,
@@ -84,14 +79,13 @@ describe("SettingsModal", () => {
     expect(await screen.findByText("Update")).toBeInTheDocument();
   });
 
-  test("renders the Computer Use page from the main settings nav", async () => {
+  test("does not render a Computer Use entry in the main settings nav", async () => {
     renderSettingsModal();
 
     await screen.findByText("Appearance Content");
-    // The Computer Use nav entry lives in the main settings area (not dev).
-    fireEvent.click(screen.getByText("Computer Use"));
-
-    expect(await screen.findByText("Computer Use Content")).toBeInTheDocument();
+    // Computer Use configuration moved into the plugins panel; the settings
+    // modal must no longer mount or navigate to it.
+    expect(screen.queryByText("Computer Use")).not.toBeInTheDocument();
   });
 
   test("hides the Update page when the app update feature flag is disabled", async () => {

--- a/src/COMPONENTs/settings/settings_modal_content.js
+++ b/src/COMPONENTs/settings/settings_modal_content.js
@@ -8,7 +8,6 @@ import { MemorySettings } from "./memory";
 import { RuntimeSettings } from "./runtime";
 import { AppUpdateSettings } from "./app_update";
 import { TokenUsageSettings } from "./token_usage";
-import { ComputerUseSettings } from "./computer_use";
 import { DevSettings } from "./dev";
 import { isDevSettingsAvailable } from "./dev/storage";
 import {
@@ -22,7 +21,6 @@ const PAGE_COMPONENTS = {
   model_providers: ModelProvidersSettings,
   runtime: RuntimeSettings,
   memory: MemorySettings,
-  computer_use: ComputerUseSettings,
   token_usage: TokenUsageSettings,
   app_update: AppUpdateSettings,
   local_storage: LocalStorageSettings,
@@ -34,7 +32,6 @@ const BASE_SETTINGS_PAGES = [
   { key: "model_providers", icon: "pentagon", labelKey: "settings.model_providers" },
   { key: "runtime", icon: "folder_2", labelKey: "settings.workspaces" },
   { key: "memory", icon: "brain", labelKey: "settings.memory" },
-  { key: "computer_use", icon: "screenshot", labelKey: "settings.computer_use" },
   { key: "token_usage", icon: "bar_chart", labelKey: "settings.token_usage" },
   { key: "app_update", icon: "download_cloud", labelKey: "settings.update" },
   { key: "local_storage", icon: "data", labelKey: "settings.local_storage" },

--- a/src/COMPONENTs/toolkit/components/computer_status_pill.js
+++ b/src/COMPONENTs/toolkit/components/computer_status_pill.js
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { runtimeBridge } from "../../../SERVICEs/bridges/unchain_bridge";
+import { useTranslation } from "../../../BUILTIN_COMPONENTs/mini_react/use_translation";
+
+/**
+ * ComputerStatusPill — read-only runtime status indicator for the synthetic
+ * Computer plugin row on the Installed screen (S1).
+ *
+ * Reads the sidecar's authoritative computer-use runtime status once on mount
+ * (`runtimeBridge.getComputerUseStatus()`) and shows Enabled / Disabled. This
+ * is a STATUS indicator only, never a control: the actual on/off toggle lives
+ * exclusively in the Computer settings detail page (ComputerUseSettings),
+ * which is the single surface carrying the consent gate. Putting a switch here
+ * would let a user flip computer use on from a list row without ever passing
+ * the consent point — hence pill, not switch.
+ *
+ * Fail-closed: a failed / unavailable read (older sidecar, bridge missing,
+ * sidecar down) is NOT surfaced as an error — it collapses to Disabled, which
+ * matches the runtime contract where an unreachable sidecar means the tool is
+ * not in effect.
+ */
+export const ComputerStatusPill = ({ isDark = false }) => {
+  const { t } = useTranslation();
+  const [enabled, setEnabled] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    runtimeBridge
+      .getComputerUseStatus()
+      .then((status) => {
+        if (!cancelled) setEnabled(Boolean(status?.enabled));
+      })
+      .catch(() => {
+        if (!cancelled) setEnabled(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const palette = enabled
+    ? {
+        color: isDark ? "#86efac" : "#2e7d32",
+        background: isDark ? "rgba(134,239,172,0.14)" : "rgba(46,125,50,0.10)",
+      }
+    : {
+        color: isDark
+          ? "rgba(var(--pupu-text-rgb),0.5)"
+          : "rgba(var(--pupu-text-rgb),0.45)",
+        background: isDark
+          ? "rgba(var(--pupu-text-rgb),0.08)"
+          : "rgba(var(--pupu-text-rgb),0.05)",
+      };
+
+  return (
+    <span
+      data-testid="computer-status-pill"
+      style={{
+        fontSize: 10.5,
+        fontWeight: 500,
+        letterSpacing: "0.02em",
+        color: palette.color,
+        background: palette.background,
+        borderRadius: 999,
+        padding: "3px 9px",
+        whiteSpace: "nowrap",
+      }}
+    >
+      {enabled
+        ? t("computer_use.status_enabled")
+        : t("computer_use.status_disabled")}
+    </span>
+  );
+};
+
+export default ComputerStatusPill;

--- a/src/COMPONENTs/toolkit/components/computer_status_pill.test.js
+++ b/src/COMPONENTs/toolkit/components/computer_status_pill.test.js
@@ -1,0 +1,75 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+import ComputerStatusPill from "./computer_status_pill";
+import { runtimeBridge } from "../../../SERVICEs/bridges/unchain_bridge";
+
+jest.mock("../../../BUILTIN_COMPONENTs/mini_react/use_translation", () => ({
+  __esModule: true,
+  useTranslation: () => ({ t: (key) => key, locale: "en", setLocale: () => {} }),
+}));
+
+jest.mock("../../../SERVICEs/bridges/unchain_bridge", () => ({
+  __esModule: true,
+  runtimeBridge: { getComputerUseStatus: jest.fn() },
+}));
+
+describe("ComputerStatusPill", () => {
+  beforeEach(() => {
+    runtimeBridge.getComputerUseStatus.mockReset();
+  });
+
+  const renderPill = async () => {
+    await act(async () => {
+      render(<ComputerStatusPill isDark={false} />);
+    });
+  };
+
+  test("shows the Enabled status when the runtime reports enabled", async () => {
+    runtimeBridge.getComputerUseStatus.mockResolvedValue({ enabled: true });
+    await renderPill();
+    await waitFor(() =>
+      expect(screen.getByTestId("computer-status-pill")).toHaveTextContent(
+        "computer_use.status_enabled",
+      ),
+    );
+  });
+
+  test("shows the Disabled status when the runtime reports disabled", async () => {
+    runtimeBridge.getComputerUseStatus.mockResolvedValue({ enabled: false });
+    await renderPill();
+    await waitFor(() =>
+      expect(screen.getByTestId("computer-status-pill")).toHaveTextContent(
+        "computer_use.status_disabled",
+      ),
+    );
+  });
+
+  /* Fail-closed: an unreachable / erroring status read is not an error state —
+     it collapses to Disabled. */
+  test("collapses to Disabled when the status read fails", async () => {
+    runtimeBridge.getComputerUseStatus.mockRejectedValue(
+      new Error("bridge_unavailable"),
+    );
+    await renderPill();
+    await waitFor(() =>
+      expect(screen.getByTestId("computer-status-pill")).toHaveTextContent(
+        "computer_use.status_disabled",
+      ),
+    );
+  });
+
+  test("defaults to Disabled before the status resolves", async () => {
+    let resolve;
+    runtimeBridge.getComputerUseStatus.mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      }),
+    );
+    await renderPill();
+    expect(screen.getByTestId("computer-status-pill")).toHaveTextContent(
+      "computer_use.status_disabled",
+    );
+    await act(async () => {
+      resolve({ enabled: true });
+    });
+  });
+});

--- a/src/COMPONENTs/toolkit/pages/plugins_installed_page.js
+++ b/src/COMPONENTs/toolkit/pages/plugins_installed_page.js
@@ -10,6 +10,8 @@ import { subscribeToolkitCatalogRefresh } from "../../../SERVICEs/toolkit_catalo
 import { toPluginPresentation } from "../../../SERVICEs/plugin_presentation";
 import { isBaseToolkitId } from "../utils/plugin_actions";
 import PluginListRow from "../components/plugin_list_row";
+import ComputerStatusPill from "../components/computer_status_pill";
+import { BUILTIN_COMPUTER_TOOLKIT_ID } from "../plugin_settings_registry";
 import { SettingsSection } from "../../settings/appearance";
 import { SemiSwitch } from "../../../BUILTIN_COMPONENTs/input/switch";
 import { Input } from "../../../BUILTIN_COMPONENTs/input/input";
@@ -42,6 +44,7 @@ const PluginsInstalledPage = ({
   onHandlersReady,
   onOpenCustomMcp,
   onOpenImportSkills,
+  onOpenPluginSettings,
 }) => {
   const { theme } = useContext(ConfigContext);
   const { t } = useTranslation();
@@ -138,6 +141,31 @@ const PluginsInstalledPage = ({
     });
   }, [rows, search]);
 
+  /* Synthetic builtin "Computer" row (S1) — NOT a catalog toolkit (the sidecar
+     never emits it from the tool-modal catalog; it rides the chat payload as a
+     synthetic id, same as the attach-panel Computer entry). It is always shown
+     in the Built-in section, participates in the page search (name/tagline),
+     and its right slot is a READ-ONLY status pill — the on/off toggle and the
+     consent gate live only in its settings detail page. Row click opens that
+     detail via onOpenPluginSettings, not the catalog-detail onOpenDetail. */
+  const computerRow = useMemo(
+    () => ({
+      toolkitId: BUILTIN_COMPUTER_TOOLKIT_ID,
+      name: t("toolkit.builtin_computer_name"),
+      tagline: t("toolkit.builtin_computer_tagline"),
+      icon: "mouse",
+    }),
+    [t],
+  );
+  const computerVisible = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return true;
+    return (
+      computerRow.name.toLowerCase().includes(q) ||
+      computerRow.tagline.toLowerCase().includes(q)
+    );
+  }, [search, computerRow]);
+
   const fontFamily = theme?.font?.fontFamily || "Jost, sans-serif";
   const tertiaryText = isDark ? "rgba(var(--pupu-text-rgb),0.38)" : "rgba(var(--pupu-text-rgb),0.35)";
   const dividerColor = "rgba(var(--pupu-text-rgb),0.06)";
@@ -212,19 +240,25 @@ const PluginsInstalledPage = ({
     </div>
   );
 
-  if (toolkits.length === 0) {
-    return (
-      <div style={{ display: "flex", flexDirection: "column" }}>
-        <PlaceholderBlock
-          icon="download"
-          title={t("toolkit.no_toolkits_title")}
-          subtitle={t("toolkit.no_toolkits_subtitle")}
-          isDark={isDark}
-        />
-        {customMcpFooter}
-      </div>
-    );
-  }
+  /* No empty-catalog short-circuit any more: the synthetic Computer row is
+     always present in the Built-in section, so the Installed screen is never
+     truly empty. An empty real catalog just renders the header + a Built-in
+     section containing only Computer + the footer. (The connectivity-error
+     placeholder above still stands — that's a distinct sidecar-down state.) */
+
+  const renderComputerRow = () => (
+    <PluginListRow
+      key={computerRow.toolkitId}
+      icon={computerRow.icon}
+      isDark={isDark}
+      name={computerRow.name}
+      description={computerRow.tagline}
+      onOpenDetail={() => onOpenPluginSettings?.(computerRow.toolkitId)}
+      testId={`installed-row-${computerRow.toolkitId}`}
+    >
+      <ComputerStatusPill isDark={isDark} />
+    </PluginListRow>
+  );
 
   const renderRow = ({ toolkit: tk, presentation }) => (
     <PluginListRow
@@ -292,14 +326,15 @@ const PluginsInstalledPage = ({
 
       {/* ── Scrollable body — Built-in / MCP SettingsSections + footer. ── */}
       <div className="scrollable" style={{ flex: 1, overflowY: "auto", padding: "0 26px 26px" }}>
-        {filteredRows.length === 0 && (
+        {filteredRows.length === 0 && !computerVisible && (
           <div style={{ fontSize: 12, fontFamily, color: tertiaryText, padding: "16px 0" }}>
             {t("toolkit.installed_no_matches")}
           </div>
         )}
 
-        {builtinRows.length > 0 && (
+        {(computerVisible || builtinRows.length > 0) && (
           <SettingsSection title={t("toolkit.source_builtin")}>
+            {computerVisible && renderComputerRow()}
             {builtinRows.map(renderRow)}
           </SettingsSection>
         )}

--- a/src/COMPONENTs/toolkit/pages/plugins_installed_page.test.js
+++ b/src/COMPONENTs/toolkit/pages/plugins_installed_page.test.js
@@ -65,6 +65,14 @@ jest.mock("../../../BUILTIN_COMPONENTs/tooltip/tooltip", () => ({
   default: ({ children }) => children,
 }));
 
+/* Stub the status pill so this list-level test never touches runtimeBridge —
+   the pill's own tri-state behavior is covered in computer_status_pill.test.js.
+   Text is "status" (no "tool") to keep the plugin-vocabulary assertion valid. */
+jest.mock("../components/computer_status_pill", () => ({
+  __esModule: true,
+  default: () => <span data-testid="computer-status-pill">status</span>,
+}));
+
 const CATALOG = [
   {
     toolkitId: "plan",
@@ -260,6 +268,66 @@ describe("PluginsInstalledPage", () => {
       expect(screen.getByText(/Add a custom plugin/i)).toBeInTheDocument();
       fireEvent.click(screen.getByText(/Add a custom plugin/i));
       expect(onOpenCustomMcp).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  /* S1: the builtin Computer plugin is a synthetic row that is always shown in
+     the Built-in section (not part of the catalog), carries a read-only status
+     pill (no auto-enable switch), and opens its settings detail — not the
+     catalog detail — on click. */
+  describe("PluginsInstalledPage — synthetic Computer row", () => {
+    test("always renders the Computer row with its read-only status pill", async () => {
+      await renderPage();
+
+      expect(screen.getByText("Computer")).toBeInTheDocument();
+      expect(screen.getByTestId("computer-status-pill")).toBeInTheDocument();
+    });
+
+    test("Computer row carries no auto-enable switch (pill only, toggle lives in detail)", async () => {
+      await renderPage();
+
+      // Only the two catalog plugins get switches; Computer does not.
+      expect(screen.getAllByTestId("switch")).toHaveLength(2);
+    });
+
+    test("clicking the Computer row opens its settings detail, not the catalog detail", async () => {
+      const onOpenPluginSettings = jest.fn();
+      const onOpenDetail = jest.fn();
+      await renderPage({ onOpenPluginSettings, onOpenDetail });
+
+      fireEvent.click(screen.getByText("Computer"));
+
+      expect(onOpenPluginSettings).toHaveBeenCalledTimes(1);
+      expect(onOpenPluginSettings).toHaveBeenCalledWith("builtin.computer");
+      expect(onOpenDetail).not.toHaveBeenCalled();
+    });
+
+    test("is shown even when the real catalog is empty", async () => {
+      api.unchain.listToolModalCatalog.mockResolvedValue({ toolkits: [] });
+      await renderPage();
+
+      expect(screen.getByText("Computer")).toBeInTheDocument();
+    });
+
+    test("participates in search — hidden when the query doesn't match", async () => {
+      await renderPage();
+
+      fireEvent.change(screen.getByPlaceholderText("Search plugins..."), {
+        target: { value: "Notion" },
+      });
+
+      expect(screen.queryByText("Computer")).not.toBeInTheDocument();
+    });
+
+    test("participates in search — kept when the query matches its name", async () => {
+      await renderPage();
+
+      fireEvent.change(screen.getByPlaceholderText("Search plugins..."), {
+        target: { value: "Comp" },
+      });
+
+      expect(screen.getByText("Computer")).toBeInTheDocument();
+      expect(screen.queryByText("Plan")).not.toBeInTheDocument();
     });
   });
 });

--- a/src/COMPONENTs/toolkit/plugin_settings_registry.js
+++ b/src/COMPONENTs/toolkit/plugin_settings_registry.js
@@ -1,0 +1,55 @@
+import { ComputerUseSettings } from "../settings/computer_use";
+
+/**
+ * Plugin-settings component registry (S1).
+ *
+ * Maps a plugin's `toolkitId` to the in-panel settings component the plugins
+ * detail overlay (plugins_shell.js, `kind: "plugin_settings"`) mounts for it.
+ * This is the extension point for builtin plugins that carry their own
+ * configuration surface inside the plugins modal; today the only entry is the
+ * builtin Computer tool → ComputerUseSettings.
+ *
+ * Design constraints (S1):
+ *  - Keyed by EXACT toolkitId. There is deliberately NO source/prefix
+ *    fallback — a plugin either has a bespoke settings surface registered here
+ *    or it does not. Adding a fallback is a future decision, not built now.
+ *  - Cross-domain import of `../settings/computer_use` follows the existing
+ *    toolkit → `../settings/appearance` precedent (SettingsSection is imported
+ *    the same way by plugins_installed_page.js). The computer_use directory is
+ *    NOT modified — it is consumed as-is.
+ *  - Component contract: `({ toolkitId, isDark, onRequestClose })`.
+ *    ComputerUseSettings ignores all three (it reads `isDark` from
+ *    ConfigContext and owns its own lifecycle); the props are declared for
+ *    future registry entries that may need them.
+ */
+
+/**
+ * Canonical toolkitId of the builtin Computer plugin. Matches the synthetic id
+ * the sidecar funnel recognizes (`COMPUTER_TOOLKIT_ID` in
+ * chat-input/utils/computer_use_toolkit_option.js). Kept local to the toolkit
+ * surface so the registry + installed row share one source of truth without
+ * reaching into the chat-input dev's module.
+ */
+export const BUILTIN_COMPUTER_TOOLKIT_ID = "builtin.computer";
+
+export const PLUGIN_SETTINGS_REGISTRY = {
+  [BUILTIN_COMPUTER_TOOLKIT_ID]: {
+    Component: ComputerUseSettings,
+    labelKey: "toolkit.builtin_computer_name",
+    icon: "mouse",
+  },
+};
+
+/**
+ * Resolve the plugin-settings registry entry for a toolkitId, or null if none
+ * is registered. Exact-match only; any non-string / empty / unknown id → null.
+ *
+ * @param {string} toolkitId
+ * @returns {{ Component: Function, labelKey: string, icon: string } | null}
+ */
+export const getPluginSettingsEntry = (toolkitId) => {
+  if (typeof toolkitId !== "string" || toolkitId === "") return null;
+  return PLUGIN_SETTINGS_REGISTRY[toolkitId] || null;
+};
+
+export default getPluginSettingsEntry;

--- a/src/COMPONENTs/toolkit/plugin_settings_registry.real.test.js
+++ b/src/COMPONENTs/toolkit/plugin_settings_registry.real.test.js
@@ -1,0 +1,47 @@
+import { act, render, screen } from "@testing-library/react";
+import { getPluginSettingsEntry } from "./plugin_settings_registry";
+
+/* This is the REAL registry (computer_use NOT mocked) — it verifies the S1
+   cross-domain wiring end to end: the toolkit surface can resolve and mount
+   the real ComputerUseSettings (which pulls the full consent-modal /
+   enable-controller stack) without throwing. This is the assertion behind the
+   "consent nested modal renders inside the plugins modal" concern: the plugins
+   overlay container is a plain div inside the same Modal primitive the settings
+   modal uses, and ComputerUseSettings mounts its consent machinery the same way
+   there (precedent). The consent modal's own open/agree/decline behavior is
+   covered in computer_use/consent_modal.test.js.
+
+   Only runtimeBridge is mocked — with every availability probe false so the
+   panel settles into its safe "unavailable" state and never reaches for a real
+   window bridge on mount. */
+jest.mock("../../SERVICEs/bridges/unchain_bridge", () => ({
+  __esModule: true,
+  runtimeBridge: {
+    isComputerUseStatusAvailable: () => false,
+    isComputerUseEnableAvailable: () => false,
+    isComputerUsePrivacySettingsAvailable: () => false,
+    getComputerUseStatus: jest.fn(() => Promise.resolve({ enabled: false })),
+  },
+}));
+
+describe("plugin_settings_registry (real ComputerUseSettings mount)", () => {
+  test("the registered builtin.computer component mounts and renders its settings surface", async () => {
+    const entry = getPluginSettingsEntry("builtin.computer");
+    expect(entry).not.toBeNull();
+    const ComputerUseSettings = entry.Component;
+
+    await act(async () => {
+      render(
+        <ComputerUseSettings
+          toolkitId="builtin.computer"
+          isDark={false}
+          onRequestClose={() => {}}
+        />,
+      );
+    });
+
+    // Real en.json copy for computer_use.section — proves a genuine mount, not
+    // a stub, and that the full consent/enable-controller import graph loaded.
+    expect(screen.getByText("Computer Use")).toBeInTheDocument();
+  });
+});

--- a/src/COMPONENTs/toolkit/plugin_settings_registry.test.js
+++ b/src/COMPONENTs/toolkit/plugin_settings_registry.test.js
@@ -1,0 +1,48 @@
+/* Mock the cross-domain computer_use import so the registry unit test never
+   pulls the (heavy, bridge-touching) ComputerUseSettings stack — resolution is
+   the only thing under test here. */
+jest.mock("../settings/computer_use", () => ({
+  __esModule: true,
+  ComputerUseSettings: function ComputerUseSettingsStub() {
+    return null;
+  },
+}));
+
+const {
+  getPluginSettingsEntry,
+  PLUGIN_SETTINGS_REGISTRY,
+  BUILTIN_COMPUTER_TOOLKIT_ID,
+} = require("./plugin_settings_registry");
+const { ComputerUseSettings } = require("../settings/computer_use");
+
+describe("plugin_settings_registry", () => {
+  test("the builtin Computer id is the canonical synthetic id", () => {
+    expect(BUILTIN_COMPUTER_TOOLKIT_ID).toBe("builtin.computer");
+  });
+
+  test("resolves builtin.computer to ComputerUseSettings with its label + icon", () => {
+    const entry = getPluginSettingsEntry("builtin.computer");
+    expect(entry).not.toBeNull();
+    expect(entry.Component).toBe(ComputerUseSettings);
+    expect(entry.labelKey).toBe("toolkit.builtin_computer_name");
+    expect(entry.icon).toBe("mouse");
+  });
+
+  test("registers exactly one entry (Computer is the only S1 surface)", () => {
+    expect(Object.keys(PLUGIN_SETTINGS_REGISTRY)).toEqual(["builtin.computer"]);
+  });
+
+  /* Exact-id match only — deliberately no source/prefix fallback (a future
+     decision, not built in S1). */
+  test.each([
+    ["unknown id", "builtin.unknown"],
+    ["a store-style id", "mcp.productivity.notion"],
+    ["a source prefix", "builtin"],
+    ["empty string", ""],
+    ["null", null],
+    ["undefined", undefined],
+    ["a number", 123],
+  ])("returns null for %s", (_label, id) => {
+    expect(getPluginSettingsEntry(id)).toBeNull();
+  });
+});

--- a/src/COMPONENTs/toolkit/plugins_shell.js
+++ b/src/COMPONENTs/toolkit/plugins_shell.js
@@ -10,6 +10,7 @@ import ImportSkillsPage from "./pages/import_skills_page";
 import Button from "../../BUILTIN_COMPONENTs/input/button";
 import { isBuiltinToolkit } from "./utils/toolkit_helpers";
 import { deletePluginToolkit } from "./utils/plugin_actions";
+import { getPluginSettingsEntry } from "./plugin_settings_registry";
 import api from "../../SERVICEs/api";
 import { toPluginPresentation } from "../../SERVICEs/plugin_presentation";
 import {
@@ -150,6 +151,17 @@ export const PluginsShell = ({
   const handleOpenImportSkills = useCallback(() => {
     openDetail({ kind: "import_skills" });
   }, [openDetail]);
+
+  /* Plugin settings (S1) — a builtin plugin with a bespoke in-panel settings
+     surface (registered in plugin_settings_registry.js) opens it through the
+     same slide-in overlay. Today's only entry is builtin.computer →
+     ComputerUseSettings, reached from the synthetic Computer row on Installed. */
+  const handleOpenPluginSettings = useCallback(
+    (toolkitId) => {
+      openDetail({ kind: "plugin_settings", toolkitId });
+    },
+    [openDetail],
+  );
 
   /* Discover mixes two plugin sources (MCP-store-installable plugins and
      already-available builtin/local plugins pulled from the catalog), so its
@@ -487,6 +499,7 @@ export const PluginsShell = ({
           onHandlersReady={handleHandlersReady}
           onOpenCustomMcp={handleOpenCustomMcp}
           onOpenImportSkills={handleOpenImportSkills}
+          onOpenPluginSettings={handleOpenPluginSettings}
         />
       );
     }
@@ -756,6 +769,54 @@ export const PluginsShell = ({
                   <ImportSkillsPage isDark={isDark} onDone={handleSkillPackImported} />
                 </div>
               </div>
+            ) : selectedToolkit.kind === "plugin_settings" ? (
+              (() => {
+                /* S1: a builtin plugin's own settings surface, resolved from
+                   plugin_settings_registry by exact toolkitId. Container mirrors
+                   the custom / import_skills branches (back header + scrollable
+                   body). No install/delete/approve affordance and no
+                   TRUST_CONFIG vocabulary — this is a builtin, not a store
+                   entry (trust-partition, design §4). */
+                const settingsEntry = getPluginSettingsEntry(selectedToolkit.toolkitId);
+                const SettingsComponent = settingsEntry?.Component || null;
+                return (
+                  <div style={{ display: "flex", flexDirection: "column", height: "100%", paddingRight: 24 }}>
+                    <div style={{ marginBottom: 16, display: "flex", alignItems: "center", gap: 10 }}>
+                      <Button
+                        prefix_icon="arrow_left"
+                        onClick={closeDetail}
+                        style={{
+                          fontSize: 12,
+                          fontWeight: 500,
+                          color: isDark ? "rgba(var(--pupu-text-rgb),0.72)" : "rgba(var(--pupu-text-rgb),0.68)",
+                          paddingVertical: 5,
+                          paddingHorizontal: 5,
+                          borderRadius: 8,
+                          root: { background: isDark ? "rgba(var(--pupu-text-rgb),0.05)" : "rgba(var(--pupu-text-rgb),0.04)" },
+                          hoverBackgroundColor: isDark ? "rgba(var(--pupu-text-rgb),0.08)" : "rgba(var(--pupu-text-rgb),0.07)",
+                          activeBackgroundColor: isDark ? "rgba(var(--pupu-text-rgb),0.12)" : "rgba(var(--pupu-text-rgb),0.1)",
+                          content: {
+                            prefixIconWrap: { display: "flex", alignItems: "center", justifyContent: "center", lineHeight: 0 },
+                            icon: { width: 14, height: 14 },
+                          },
+                        }}
+                      />
+                      <span style={{ fontSize: 15, fontWeight: 500, color: "var(--pupu-text)" }}>
+                        {settingsEntry ? t(settingsEntry.labelKey) : ""}
+                      </span>
+                    </div>
+                    <div className="scrollable" style={{ flex: 1, overflowY: "auto", paddingBottom: 20 }}>
+                      {SettingsComponent ? (
+                        <SettingsComponent
+                          toolkitId={selectedToolkit.toolkitId}
+                          isDark={isDark}
+                          onRequestClose={closeDetail}
+                        />
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })()
             ) : (
               <PluginDetailPage
                 presentation={toPluginPresentation(selectedToolkit.toolkit || {})}

--- a/src/COMPONENTs/toolkit/plugins_shell.test.js
+++ b/src/COMPONENTs/toolkit/plugins_shell.test.js
@@ -7,6 +7,7 @@ import {
   deleteMcpEntry,
 } from "../../SERVICEs/mcp_install";
 import { getMcpStoreEntry } from "../../SERVICEs/mcp_toolkit_store";
+import { getPluginSettingsEntry } from "./plugin_settings_registry";
 
 jest.mock("../../BUILTIN_COMPONENTs/mini_react/use_translation", () => ({
   __esModule: true,
@@ -41,7 +42,32 @@ jest.mock("./pages/plugins_categories_page", () => ({
 
 jest.mock("./pages/plugins_installed_page", () => ({
   __esModule: true,
-  default: () => <div>Installed Page</div>,
+  default: ({ onOpenPluginSettings }) => (
+    <div>
+      <span>Installed Page</span>
+      <button onClick={() => onOpenPluginSettings?.("builtin.computer")}>
+        Open Computer Settings
+      </button>
+    </div>
+  ),
+}));
+
+/* Stub the plugin-settings registry so the overlay-branch test mounts a tiny
+   stand-in instead of the real ComputerUseSettings (its cross-domain mount is
+   covered separately in plugin_settings_registry.real.test.js). */
+jest.mock("./plugin_settings_registry", () => ({
+  __esModule: true,
+  getPluginSettingsEntry: jest.fn((id) =>
+    id === "builtin.computer"
+      ? {
+          Component: ({ toolkitId }) => (
+            <div>Computer Settings Panel: {toolkitId}</div>
+          ),
+          labelKey: "toolkit.builtin_computer_name",
+          icon: "mouse",
+        }
+      : null,
+  ),
 }));
 
 jest.mock("./pages/plugin_detail_page", () => ({
@@ -216,6 +242,19 @@ describe("PluginsShell", () => {
       if (id === "installed-ready.sample") return INSTALLED_READY_ENTRY;
       return null;
     });
+    /* resetMocks wipes the jest.mock factory impl each test — re-establish the
+       registry stub (Computer settings panel stand-in). */
+    getPluginSettingsEntry.mockImplementation((id) =>
+      id === "builtin.computer"
+        ? {
+            Component: ({ toolkitId }) => (
+              <div>Computer Settings Panel: {toolkitId}</div>
+            ),
+            labelKey: "toolkit.builtin_computer_name",
+            icon: "mouse",
+          }
+        : null,
+    );
   });
 
   const renderShell = async (props = {}) => {
@@ -421,6 +460,49 @@ describe("PluginsShell", () => {
     });
 
     expect(screen.getByText("Auto Enabled: true")).toBeInTheDocument();
+  });
+
+  /* S1: the Installed page's synthetic Computer row opens the builtin
+     plugin-settings overlay through the shell (kind: "plugin_settings"),
+     resolving its component from plugin_settings_registry by toolkitId. The
+     overlay container mirrors the custom / import_skills branches (back header
+     + scrollable body). */
+  test("opening plugin settings from Installed mounts the registered settings component", async () => {
+    await renderShell({ activePage: "installed" });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Open Computer Settings"));
+    });
+
+    expect(
+      screen.getByText("Computer Settings Panel: builtin.computer"),
+    ).toBeInTheDocument();
+    // header label comes from the registry entry's labelKey
+    expect(screen.getByText("toolkit.builtin_computer_name")).toBeInTheDocument();
+  });
+
+  test("plugin-settings overlay back button returns to the Installed page", async () => {
+    await renderShell({ activePage: "installed" });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Open Computer Settings"));
+    });
+    expect(
+      screen.getByText("Computer Settings Panel: builtin.computer"),
+    ).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByTestId("icon-arrow_left").closest("button"),
+      );
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.queryByText("Computer Settings Panel: builtin.computer"),
+      ).not.toBeInTheDocument(),
+    );
+    expect(screen.getByText("Installed Page")).toBeInTheDocument();
   });
 
   /* T1 (settings-isomorphic restyle): the App-Store-era per-item indigo

--- a/src/COMPONENTs/toolkit/toolkit_modal.js
+++ b/src/COMPONENTs/toolkit/toolkit_modal.js
@@ -64,7 +64,10 @@ export const ToolkitModal = ({ open, onClose }) => {
       const visible = list.filter(
         (tk) => tk.source !== "plugin" && !tk.hidden && !isBaseById(tk.toolkitId),
       );
-      setInstalledCount(visible.length);
+      /* +1 for the synthetic builtin Computer row the Installed page always
+         renders (S1) — it is not part of the catalog, so add it here to keep
+         the sidebar badge == the number of rows the Installed screen shows. */
+      setInstalledCount(visible.length + 1);
     } catch {
       /* keep previous count */
     }

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Computer",
+    "builtin_computer_tagline": "Sieht deinen Bildschirm und steuert Maus und Tastatur",
     "kind_core": "Kern",
     "kind_builtin": "Integriert",
     "kind_integration": "Integration",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -5,7 +5,6 @@
     "model_providers": "Anbieter",
     "workspaces": "Arbeitsbereich",
     "memory": "Speicher",
-    "computer_use": "Computernutzung",
     "token_usage": "Tokens",
     "update": "Update",
     "local_storage": "Speicher",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -5,7 +5,6 @@
     "model_providers": "Model Providers",
     "workspaces": "Workspaces",
     "memory": "Memory",
-    "computer_use": "Computer Use",
     "token_usage": "Token Usage",
     "update": "Update",
     "local_storage": "Local Storage",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -480,6 +480,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Computer",
+    "builtin_computer_tagline": "See your screen and control the mouse and keyboard",
     "kind_core": "Core",
     "kind_builtin": "Built-in",
     "kind_integration": "Integration",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -5,7 +5,6 @@
     "model_providers": "Proveedores",
     "workspaces": "Espacios",
     "memory": "Memoria",
-    "computer_use": "Uso del ordenador",
     "token_usage": "Tokens",
     "update": "Actualizar",
     "local_storage": "Almacenamiento",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Computadora",
+    "builtin_computer_tagline": "Ve tu pantalla y controla el ratón y el teclado",
     "kind_core": "Núcleo",
     "kind_builtin": "Integrado",
     "kind_integration": "Integración",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Ordinateur",
+    "builtin_computer_tagline": "Voit votre écran et contrôle la souris et le clavier",
     "kind_core": "Noyau",
     "kind_builtin": "Intégré",
     "kind_integration": "Intégration",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -5,7 +5,6 @@
     "model_providers": "Fournisseurs",
     "workspaces": "Espaces",
     "memory": "Mémoire",
-    "computer_use": "Contrôle de l'ordinateur",
     "token_usage": "Tokens",
     "update": "Mise à jour",
     "local_storage": "Stockage",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -5,7 +5,6 @@
     "model_providers": "Provider",
     "workspaces": "Spazi",
     "memory": "Memoria",
-    "computer_use": "Uso del computer",
     "token_usage": "Token",
     "update": "Aggiorna",
     "local_storage": "Archivio",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Computer",
+    "builtin_computer_tagline": "Vede lo schermo e controlla mouse e tastiera",
     "kind_core": "Core",
     "kind_builtin": "Integrato",
     "kind_integration": "Integrazione",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -5,7 +5,6 @@
     "model_providers": "プロバイダー",
     "workspaces": "ワークスペース",
     "memory": "メモリ",
-    "computer_use": "コンピュータ操作",
     "token_usage": "トークン",
     "update": "アップデート",
     "local_storage": "ストレージ",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "コンピュータ",
+    "builtin_computer_tagline": "画面を見てマウスとキーボードを操作します",
     "kind_core": "コア",
     "kind_builtin": "組込み",
     "kind_integration": "統合",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -5,7 +5,6 @@
     "model_providers": "프로바이더",
     "workspaces": "워크스페이스",
     "memory": "메모리",
-    "computer_use": "컴퓨터 사용",
     "token_usage": "토큰",
     "update": "업데이트",
     "local_storage": "스토리지",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "컴퓨터",
+    "builtin_computer_tagline": "화면을 보고 마우스와 키보드를 제어합니다",
     "kind_core": "코어",
     "kind_builtin": "기본",
     "kind_integration": "통합",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Computador",
+    "builtin_computer_tagline": "Vê a sua tela e controla o mouse e o teclado",
     "kind_core": "Núcleo",
     "kind_builtin": "Integrado",
     "kind_integration": "Integração",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -5,7 +5,6 @@
     "model_providers": "Provedores",
     "workspaces": "Espaços",
     "memory": "Memória",
-    "computer_use": "Uso do computador",
     "token_usage": "Tokens",
     "update": "Atualizar",
     "local_storage": "Armazenamento",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -5,7 +5,6 @@
     "model_providers": "Провайдеры",
     "workspaces": "Воркспейс",
     "memory": "Память",
-    "computer_use": "Управление компьютером",
     "token_usage": "Токены",
     "update": "Обновление",
     "local_storage": "Хранилище",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "Компьютер",
+    "builtin_computer_tagline": "Видит экран и управляет мышью и клавиатурой",
     "kind_core": "Ядро",
     "kind_builtin": "Встроенный",
     "kind_integration": "Интеграция",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -5,7 +5,6 @@
     "model_providers": "模型提供商",
     "workspaces": "工作区",
     "memory": "记忆",
-    "computer_use": "电脑操作",
     "token_usage": "Token 用量",
     "update": "更新",
     "local_storage": "本地存储",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -421,6 +421,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "电脑",
+    "builtin_computer_tagline": "查看你的屏幕并控制鼠标和键盘",
     "kind_core": "核心",
     "kind_builtin": "内置",
     "kind_integration": "集成",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -5,7 +5,6 @@
     "model_providers": "模型供應商",
     "workspaces": "工作區",
     "memory": "記憶",
-    "computer_use": "電腦操作",
     "token_usage": "Token 用量",
     "update": "更新",
     "local_storage": "本機儲存",

--- a/src/locales/zh-TW.json
+++ b/src/locales/zh-TW.json
@@ -375,6 +375,8 @@
     }
   },
   "toolkit": {
+    "builtin_computer_name": "電腦",
+    "builtin_computer_tagline": "查看你的螢幕並控制滑鼠和鍵盤",
     "kind_core": "核心",
     "kind_builtin": "內建",
     "kind_integration": "整合",


### PR DESCRIPTION
## Summary

Moves Computer Use configuration out of Settings and into the **plugins panel**, per CEO direction: capabilities all live in one place, and this establishes the **per-plugin settings page contract** that future toolkit customization (per-tool write confirmations, OAuth management, …) will reuse.

- **Installed → Built-in section** gains a synthetic "Computer" row (mouse icon, read-only On/Off status pill from server truth, always visible, participates in search). Not in the MCP catalog — same synthetic-entry precedent as the chat attach menu; backend untouched.
- **Row click opens a detail overlay** (existing `openDetail` mechanism, new `plugin_settings` kind) hosting the exact same `ComputerUseSettings` component — toggle, one-time consent, macOS permission badges. **UI moved, vessels untouched**: `settings/computer_use/` directory has zero changes; `enable_controller` remains the renderer's single call site (grep-test still passes unmodified).
- **New `plugin_settings_registry.js`** — the generic contract: `toolkitId → {Component, labelKey, icon}`. One entry today (`builtin.computer`); MCP per-tool permission panels register here later (exact-id keys now, `source:` fallback reserved as a future extension).
- **Settings nav entry removed** (added in #184; this supersedes it). All 11 locales updated both ways (nav key removed, plugin name/tagline added).

### Trust partition

Computer sits in the Built-in section with the builtin badge, physically separated from third-party MCP entries; its detail page renders **no TRUST_CONFIG vocabulary** (verified/community/needs_review is store trust language) and no install/delete/approve affordances.

### Security

All eight Gate-B invariants re-confirmed unaffected (component remounted, module untouched; status pill is read-only and fail-closed to Off; backend/IPC/localStorage untouched; `boot_sync` stays mounted in App.js). Deliberately avoided the hero/discover/categories/detail files under active development — the only shared touch is a minimal additive branch in `plugins_shell.js`.

### Tests

- Frontend: **2037 passed / 276 suites** (+23: registry resolution, real cross-domain mount incl. nested consent modal, pill tri-state, synthetic row visibility/search/click, shell overlay round-trip, settings-nav-removed regression guard)
- Backend / Electron: untouched by this PR
- ESLint on changed production files: zero warnings; all 11 locale JSONs valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)
